### PR TITLE
Fixed: wrong number of _PREESM_NBTHREADS_ when using more than one printer

### DIFF
--- a/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
+++ b/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
@@ -464,14 +464,14 @@ class CPrinter extends DefaultPrinter {
 		#include <pthread.h>
 		#include <stdio.h>
 
-		#define _PREESM_NBTHREADS_ «printerBlocks.size»
+		#define _PREESM_NBTHREADS_ «engine.codeBlocks.size»
 		#define _PREESM_MAIN_THREAD_ «mainOperatorId»
 
 		// application dependent includes
 		#include "preesm_gen.h"
 
 		// Declare computation thread functions
-		«FOR coreBlock : printerBlocks»
+		«FOR coreBlock : engine.codeBlocks»
 		void *computationThread_Core«(coreBlock as CoreBlock).coreID»(void *arg);
 		«ENDFOR»
 
@@ -525,7 +525,7 @@ class CPrinter extends DefaultPrinter {
 			// Declaring thread pointers
 			pthread_t coreThreads[_PREESM_NBTHREADS_];
 			void *(*coreThreadComputations[_PREESM_NBTHREADS_])(void *) = {
-				«FOR coreBlock : printerBlocks»&computationThread_Core«(coreBlock as CoreBlock).coreID»«if(printerBlocks.last == coreBlock) {""} else {", "}»«ENDFOR»
+				«FOR coreBlock : engine.codeBlocks»&computationThread_Core«(coreBlock as CoreBlock).coreID»«if(engine.codeBlocks.last == coreBlock) {""} else {", "}»«ENDFOR»
 			};
 
 		#ifdef VERBOSE

--- a/release_notes.md
+++ b/release_notes.md
@@ -12,6 +12,7 @@ PREESM Changelog
 
 ### Bug fix
 * Fix #108: Update log messages to display the faulty task name and id, when relevant;
+* Fix #113: Use different counter for setting thread count in code generation;
 
 ## Release version 3.4.0
 *2019.01.28*


### PR DESCRIPTION
I have only modified a few lines of the `CPrinter`. The purpose is to have a generated `main.c` with the right number of threads (that reflect the number of CPUs in the S-LAM).
The problem appears when multiple printers are used at the same time (for instance when a heterogeneous set of core_type is used in the S-LAM).
The behaviour of the `CPrinter` continues to be the same when a set of homogeneous core_type is used.