### PR TITLE
(Codegen Hardware) fix the Release Kernel Instance in the generated code

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,6 +8,7 @@ PREESM Changelog
 
 ### Changes
 *  Fix C Hardware codegen: properly prefix LOOP_SIZE with PREESM_;
+*  Fix C Hardware codegen: properly printed the Release Kernel Instance with the name of the function to be executed in Hardware
 *  Update workflow editor to better report task id issues;
 
 ### Bug fix


### PR DESCRIPTION
Fix for little bug: the purpose is to have a generic "hardware_kernel_release(...)" where the kernel name comes from the instance of the actor to be executed.