### PR TITLE
Change form of parallel expression string

### DIFF
--- a/plugins/org.preesm.algorithm/model/Schedule.xcore
+++ b/plugins/org.preesm.algorithm/model/Schedule.xcore
@@ -169,7 +169,7 @@ interface ActorSchedule extends Schedule {
 		val StringBuilder toPrint = new StringBuilder()
 		// Print sequential operator
 		if (getRepetition() > 1) {
-			toPrint.append(getRepetition() + "(")
+			toPrint.append(getRepetition())
 			if (isParallel) {
 				toPrint.append("/")
 			}


### PR DESCRIPTION
Correct the way that parallel expression are printed into string ( 3(/(A) to 3/(A) )