### PR TITLE
Add parallelism on repeated sequential hierarchical schedule

### DIFF
--- a/plugins/org.preesm.algorithm/model/Schedule.xcore
+++ b/plugins/org.preesm.algorithm/model/Schedule.xcore
@@ -108,6 +108,17 @@ interface Schedule {
 	 * returns a String representing the schedule informally.
 	 */
 	op String shortPrint()
+	/*
+	 * Returns true if the schedule repetition can be parallelize.
+	 */
+	op boolean isParallelizable() {
+		for (Schedule child : children) {
+			if (!child.isParallelizable()) {
+				return false;
+			}
+		}
+		return true;
+	}
 }
 
 /*
@@ -151,6 +162,8 @@ interface HierarchicalSchedule extends Schedule {
 	op Schedule[] getChildren() {
 		return scheduleTree
 	}
+	
+	
 }
 
 /*
@@ -192,6 +205,9 @@ interface ActorSchedule extends Schedule {
  * This schedule as no children.
  */
 class SequentialActorSchedule extends ActorSchedule, SequentialSchedule {
+	op boolean isParallelizable() {
+		return isParallel();
+	}
 }
 
 /*
@@ -201,6 +217,9 @@ class SequentialActorSchedule extends ActorSchedule, SequentialSchedule {
  * This schedule as no children.
  */
 class ParallelActorSchedule extends ActorSchedule, ParallelSchedule {
+	op boolean isParallelizable() {
+		return isParallel();
+	}
 }
 
 /*
@@ -213,7 +232,7 @@ class SequentialHiearchicalSchedule extends HierarchicalSchedule, SequentialSche
 		// Print sequential operator
 		if (getRepetition() > 1) {
 			toPrint.append(getRepetition())
-			if (isParallel()) {
+			if (isParallelizable()) {
 				toPrint.append("/");
 			}
 			toPrint.append("(")
@@ -223,14 +242,6 @@ class SequentialHiearchicalSchedule extends HierarchicalSchedule, SequentialSche
 			toPrint.append(")")
 		}
 		return toPrint.toString()
-	}
-	op boolean isParallel() {
-		for (Schedule child : children) {
-			if (!child.isParallel()) {
-				return false;
-			}
-		}
-		return true;
 	}
 }
 

--- a/plugins/org.preesm.algorithm/model/Schedule.xcore
+++ b/plugins/org.preesm.algorithm/model/Schedule.xcore
@@ -212,13 +212,25 @@ class SequentialHiearchicalSchedule extends HierarchicalSchedule, SequentialSche
 		val StringBuilder toPrint = new StringBuilder()
 		// Print sequential operator
 		if (getRepetition() > 1) {
-			toPrint.append(getRepetition() + "(")
+			toPrint.append(getRepetition())
+			if (isParallel()) {
+				toPrint.append("/");
+			}
+			toPrint.append("(")
 		}
 		toPrint.append(children.map[it.shortPrint()].join("*"))
 		if (getRepetition() > 1) {
 			toPrint.append(")")
 		}
 		return toPrint.toString()
+	}
+	op boolean isParallel() {
+		for (Schedule child : children) {
+			if (!child.isParallel()) {
+				return false;
+			}
+		}
+		return true;
 	}
 }
 


### PR DESCRIPTION
For clustering purpose, I wanted to have the possibility to parallelize a repeated sequential hierarchical schedule. Take this example:

_top_level.pi_
![example](https://user-images.githubusercontent.com/5111951/61445291-6abf2b00-a94d-11e9-91cf-1a1278a82d07.png)

_double_scalar.pi_
![sobel_new_program](https://user-images.githubusercontent.com/5111951/61445535-d73a2a00-a94d-11e9-8be3-97045dc25a84.png)

_repetition vector_
```
11:16:29 NOTICE: top_level/SendVector x1 (total: x1)
11:16:29 NOTICE: top_level/Double_Scalar x4 (total: x4)
11:16:29 NOTICE: top_level/ReceiveVector x1 (total: x1)
11:16:29 NOTICE: top_level/Double_Scalar/Scalar_1 x1 (total: x4)
11:16:29 NOTICE: top_level/Double_Scalar/Scalar_2 x1 (total: x4)
```
To be able to clusterize, this graph will be flatten with the PISDFFlattenerTask, that will give us this result: 

![flatten](https://user-images.githubusercontent.com/5111951/61445756-46b01980-a94e-11e9-8ba7-58cf29ad00fc.png)

With the actual clustering algorithm and schedule model, we are able to generated such a schedule:
`SendVector*4(Double_Scalar_Scalar_1*Double_Scalar_Scalar_2)*ReceiveVector`

The problem is that we lose the parallelism on Double_Scalar and it repetition of 4. The condition to be able to parallelize the repetition of cluster `4(Double_Scalar_Scalar_1*Double_Scalar_Scalar_2)` is to check if internal actors aren't sequential. To do so, I've overridden isParallel operation in Schedule.xcore to explore children in search of potential non-parallel actors. In addition, I've also added to shortPrint the parallel operator. Finally, we get this result for a schedule expression:
`SendVector*4/(Double_Scalar_Scalar_1*Double_Scalar_Scalar_2)*ReceiveVector`

For the implementation, we may discuss of it to be sure that non-cluster applications will not be in trouble because of that change.