### PR TITLE
Fix papify

### DIFF
--- a/plugins/org.preesm.codegen/src/org/preesm/codegen/xtend/task/CodegenModelGenerator.java
+++ b/plugins/org.preesm.codegen/src/org/preesm/codegen/xtend/task/CodegenModelGenerator.java
@@ -240,9 +240,6 @@ public class CodegenModelGenerator extends AbstractCodegenModelGenerator {
    */
   protected final List<EList<PapiEvent>> configsAdded;
 
-  /** The flag to activate PAPIFY instrumentation. */
-  private boolean papifyActive;
-
   /**
    * Constructor of the {@link CodegenModelGenerator}. The constructor performs verification to ensure that the inputs
    * are valid:

--- a/release_notes.md
+++ b/release_notes.md
@@ -31,7 +31,8 @@ PREESM Changelog
   * Refactor Topology helper methods and classes;
 
 ### Bug fix
-
+* PAPIFY:
+  * Fix PAPIFY code generation
 
 ## Release version 3.12.0
 *2019.07.11*


### PR DESCRIPTION
After the inclusion of the abstact class for the CodegenModelGenerator PAPIFY code was not printed anymore. This bug has been fixed here.