### PR TITLE
Instrumentation fixed and improved with SUM

### DIFF
--- a/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/instrumented/InstrumentedCPrinter.xtend
+++ b/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/instrumented/InstrumentedCPrinter.xtend
@@ -40,8 +40,11 @@ package org.preesm.codegen.xtend.printer.c.instrumented
 
 import java.util.ArrayList
 import java.util.Collection
+import java.util.HashMap
 import java.util.LinkedHashMap
 import java.util.List
+import java.util.Map
+import org.preesm.codegen.model.ActorFunctionCall
 import org.preesm.codegen.model.Block
 import org.preesm.codegen.model.Buffer
 import org.preesm.codegen.model.CodeElt
@@ -56,8 +59,6 @@ import org.preesm.codegen.model.SpecialCall
 import org.preesm.codegen.model.Variable
 import org.preesm.codegen.printer.PrinterState
 import org.preesm.codegen.xtend.printer.c.CPrinter
-import org.preesm.codegen.model.ActorFunctionCall
-import org.preesm.commons.logger.PreesmLogger
 import org.preesm.commons.exceptions.PreesmRuntimeException
 
 /**
@@ -289,17 +290,34 @@ class InstrumentedCPrinter extends CPrinter {
 	«super.printFifoCall(fifoCall)»
 	'''
 
+	/**
+ 	 * Write the csv file.
+	 */
 	override createSecondaryFiles(List<Block> printerBlocks, Collection<Block> allBlocks) {
 		val result = super.createSecondaryFiles(printerBlocks,allBlocks);
-		result.put("analysis.csv", printAnalysisCsvFile)
+		val mapActorNbRow = new HashMap<String, Integer>()
+		val mapActorNbFiring = new HashMap<String, Integer>()
+		var i = 1
+		for (entry: actorIDs.entrySet) {
+			val name = entry.key
+			// We can register the apparition order because it is a LinkedHashMap
+			// And we need that fot the SUM generation
+			mapActorNbRow.put(name, i)
+			mapActorNbFiring.put(name, entry.value.size)
+			i += 1
+		}
+		result.put("analysis.csv", printAnalysisCsvFile(mapActorNbRow, mapActorNbFiring))
 		return result
 	}
 
-	def String printAnalysisCsvFile()'''
+	/**
+	 * Generate the average formula for each actor, and the sum of everything.
+	 */
+	def String printAnalysisCsvFile(Map<String,Integer> mapActorNbRow, Map<String,Integer> mapActorNbFiring)'''
 	«FOR entry : actorIDs.entrySet»
-	// Or MROUND(AVERGAE(...);10)
-	«entry.key»;"=AVERAGE(«FOR id : entry.value SEPARATOR ';'»«(id+1).intToColumn»«actorIDs.size + 3»:«(id+1).intToColumn»65536«ENDFOR»)"
+	«entry.key»;"=MROUND(AVERAGE(«FOR id : entry.value SEPARATOR ';'»«(id+1).intToColumn»«actorIDs.size + 4»:«(id+1).intToColumn»65536«ENDFOR»);1)"
 	«ENDFOR»
+	"TIMINGS WEIGHTED SUM";"=SUM(«FOR entry : actorIDs.entrySet SEPARATOR ','»«mapActorNbFiring.get(entry.key)»*B«mapActorNbRow.get(entry.key)»«ENDFOR»)"
 	'''
 
 	/**


### PR DESCRIPTION
Last commit 3f1707b regarding instrumented codegen actually introduced an error (again) regarding the generation of the file analysis.csv.

The error has been fixed and the generated file has been slightly improved such that now, in addition to the average time of each actor, the sum of all the timings is provided (taking into account the repetition vector).