### PR TITLE
Spider papify update

### DIFF
--- a/plugins/org.preesm.codegen.xtend/src/org/preesm/codegen/xtend/spider/SpiderCodegenTask.java
+++ b/plugins/org.preesm.codegen.xtend/src/org/preesm/codegen/xtend/spider/SpiderCodegenTask.java
@@ -136,7 +136,12 @@ public class SpiderCodegenTask extends AbstractTaskImplementation {
     final String papifyParameter = parameters.get(SpiderCodegenTask.PARAM_PAPIFY);
     final boolean usingPapify;
     if (papifyParameter != null) {
-      usingPapify = papifyParameter.equalsIgnoreCase("true");
+      if (!scenario.getPapifyConfig().hasValidPapifyConfig()) {
+        usingPapify = false;
+        parameters.put(PARAM_PAPIFY, "false");
+      } else {
+        usingPapify = papifyParameter.equalsIgnoreCase("true");
+      }
     } else {
       usingPapify = false;
     }

--- a/plugins/org.preesm.codegen.xtend/src/org/preesm/codegen/xtend/spider/SpiderCodegenTask.java
+++ b/plugins/org.preesm.codegen.xtend/src/org/preesm/codegen/xtend/spider/SpiderCodegenTask.java
@@ -136,7 +136,7 @@ public class SpiderCodegenTask extends AbstractTaskImplementation {
     final String papifyParameter = parameters.get(SpiderCodegenTask.PARAM_PAPIFY);
     final boolean usingPapify;
     if (papifyParameter != null) {
-      usingPapify = papifyParameter.equals("true");
+      usingPapify = papifyParameter.equalsIgnoreCase("true");
     } else {
       usingPapify = false;
     }

--- a/plugins/org.preesm.model.scenario/model/Scenario.xcore
+++ b/plugins/org.preesm.model.scenario/model/Scenario.xcore
@@ -435,6 +435,9 @@ class PapifyConfig {
 		}
 		return ECollections.emptyEList;
 	}
+	op boolean hasValidPapifyConfig(){
+		return !this.papifyConfigGroupsActors.filter[e|!e.value.isEmpty].isEmpty && !this.papifyConfigGroupsPEs.filter[e|!e.value.isEmpty].isEmpty
+	}
 	op void clear() {
 		if (papiData !== null) {
 			papiData.components.clear

--- a/release_notes.md
+++ b/release_notes.md
@@ -11,6 +11,7 @@ PREESM Changelog
 * Implement simple memory allocation in the new synthesis API;
 * Prepare codegen model generator for the new synthesis API;
 * Refactor: TwinBuffer now is called DistributedBuffer;
+* SPiDER codegen considers empty PAPIFY configs as papify=false;
 
 ### Bug fix
 * fix #186


### PR DESCRIPTION
In SPiDER codegen, now, empty PAPIFY configuration is equivalent to put papify=false in the workflow