### PR TITLE
New menu entry to compute flat PiSDF, Fix #193

### DIFF
--- a/plugins/org.preesm.ui.pisdf/plugin.xml
+++ b/plugins/org.preesm.ui.pisdf/plugin.xml
@@ -230,6 +230,10 @@
             name="Compute the BRV of a PiSDF Graph">
       </command>
       <command
+            id="org.ietr.preesm.ui.command.PiSDFFlat"
+            name="Compute the flat version of this PiSDF">
+      </command>
+      <command
             id="org.ietr.preesm.ui.command.PiSDFSingleRate"
             name="Compute the Single Rate DAG of this PiSDF">
       </command>
@@ -249,6 +253,10 @@
       <handler
             class="org.preesm.ui.pisdf.popup.actions.PiSDFBRVComputePopup"
             commandId="org.ietr.preesm.ui.command.PiSDFBRVCompute">
+      </handler>
+      <handler
+            class="org.preesm.ui.pisdf.popup.actions.PiSDFFlatComputePopup"
+            commandId="org.ietr.preesm.ui.command.PiSDFFlat">
       </handler>
       <handler
             class="org.preesm.ui.pisdf.popup.actions.PiSDFSRDAGComputePopup"
@@ -429,12 +437,27 @@
 				</and>
 			</visibleWhen>
         </command>
+        <!-- Compute Flat -->
+        <command
+              commandId="org.ietr.preesm.ui.command.PiSDFFlat"
+              icon="resources/icons/pi.gif"
+              label="Compute PiSDF Flat version"
+              mnemonic="F"
+              style="push">
+			<visibleWhen checkEnabled="true">
+				<and>
+				<with variable="activePartId">
+					<equals value="org.ietr.preesm.ui.pimm.editor.diagram"/>
+				</with>
+				</and>
+			</visibleWhen>
+        </command>
         <!-- Compute SRDAG -->
         <command
               commandId="org.ietr.preesm.ui.command.PiSDFSingleRate"
               icon="resources/icons/pi.gif"
               label="Compute PiSDF SRDAG (Single Rate)"
-              mnemonic="B"
+              mnemonic="S"
               style="push">
 			<visibleWhen checkEnabled="true">
 				<and>
@@ -542,12 +565,41 @@
                   </with>
                </visibleWhen>
             </command>
+            <!-- Compute Flat version of a PiGraph -->
+            <command
+		commandId="org.ietr.preesm.ui.command.PiSDFFlat"
+		icon="resources/icons/pi.gif"
+		label="Compute PiSDF Flat version"
+                  mnemonic="F"
+                  style="push">
+               <visibleWhen
+                     checkEnabled="true">
+                  <with
+                        variable="selection">
+                     <iterate
+                           ifEmpty="false"
+                           operator="and">
+                        <adapt
+                              type="org.eclipse.core.resources.IResource">
+                           <test
+                                 property="org.eclipse.core.resources.projectNature"
+                                 value="org.ietr.preesm.core.ui.wizards.nature">
+                           </test>
+                           <test
+                                 property="org.eclipse.core.resources.extension"
+                                 value="pi">
+                           </test>
+                        </adapt>
+                     </iterate>
+                  </with>
+               </visibleWhen>
+            </command>
             <!-- Compute SRDAG of a PiGraph -->
             <command
                   commandId="org.ietr.preesm.ui.command.PiSDFSingleRate"
                   icon="resources/icons/pi.gif"
                   label="Compute PiSDF SRDAG (Single Rate)"
-                  mnemonic="C"
+                  mnemonic="S"
                   style="push">
                <visibleWhen
                      checkEnabled="true">

--- a/plugins/org.preesm.ui.pisdf/src/org/preesm/ui/pisdf/util/SavePiGraph.java
+++ b/plugins/org.preesm.ui.pisdf/src/org/preesm/ui/pisdf/util/SavePiGraph.java
@@ -1,0 +1,77 @@
+package org.preesm.ui.pisdf.util;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collection;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.ui.PlatformUI;
+import org.preesm.commons.exceptions.PreesmRuntimeException;
+import org.preesm.commons.files.WorkspaceUtils;
+import org.preesm.model.pisdf.PiGraph;
+import org.preesm.model.pisdf.serialize.PiWriter;
+import org.preesm.ui.utils.FileUtils;
+
+/**
+ * Helper to save a PiGraph from a menu command.
+ * 
+ * @author ahonorat
+ */
+public class SavePiGraph {
+
+  /**
+   * Opens a dialog box to select in which folder to write a PiGraph.
+   * <p>
+   * The folder can be picked in any project.
+   * 
+   * @param iProject
+   *          original project of the graph.
+   * @param graph
+   *          to be saved.
+   * @param suffix
+   *          appends the name of the graph to save it.
+   */
+  public static void save(final IProject iProject, final PiGraph graph, final String suffix) {
+    final IPath targetFolder = FileUtils.browseFiles(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+        "Select result location", "Select the folder where to write the computed PiGraph.", (Collection<String>) null);
+    // The commented code is kept in case we would like to restrict the writing process to the given iProject.
+
+    // final IPath inProjectPath = targetFolder.removeFirstSegments(1);
+    final String relative = targetFolder.toString();
+
+    // final String sXmlPath = WorkspaceUtils.getAbsolutePath(relative, iProject.getName());
+    IPath xmlPath = new Path(relative);
+    // Get a complete valid path with all folders existing
+    try {
+      if (xmlPath.getFileExtension() != null) {
+        WorkspaceUtils.createMissingFolders(xmlPath.removeFileExtension().removeLastSegments(1));
+      } else {
+        WorkspaceUtils.createMissingFolders(xmlPath);
+        xmlPath = xmlPath.append(graph.getName() + suffix + ".pi");
+      }
+    } catch (CoreException | IllegalArgumentException e) {
+      throw new PreesmRuntimeException("Path " + relative + " is not a valid path for export.\n" + e.getMessage());
+    }
+
+    final URI uri = URI.createPlatformResourceURI(xmlPath.toString(), true);
+    // Get the project
+    final String platformString = uri.toPlatformString(true);
+    final IFile documentFile = ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(platformString));
+    final String osString = documentFile.getLocation().toOSString();
+    try (final OutputStream outStream = new FileOutputStream(osString);) {
+      // Write the Graph to the OutputStream using the Pi format
+      new PiWriter(uri).write(graph, outStream);
+    } catch (IOException e) {
+      throw new PreesmRuntimeException("Could not open outputstream file " + xmlPath.toString());
+    }
+
+    WorkspaceUtils.updateWorkspace();
+  }
+
+}

--- a/release_notes.md
+++ b/release_notes.md
@@ -17,6 +17,7 @@ PREESM Changelog
 ### Bug fix
 * fix #186
 * Fix #189
+* Fix #193
 
 ## Release version 3.14.1
 *2019.07.25*


### PR DESCRIPTION
New menu entry to compute flat PiGraph from .pi.
If original .pi is already flat, it will perform optims on it.
If original .pi is not flat, it will flatten it without optims.
Optims are the removal of useless special actors.

Additionally: 
- modifies the mnemonic (to be unique)
- modifies the folder selection, so that the result can be written anywhere