### PR TITLE
(PiSDF) Add more rules to check mergeability

### DIFF
--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiSDFMergeabilty.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiSDFMergeabilty.java
@@ -35,6 +35,7 @@
  */
 package org.preesm.model.pisdf.util;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -97,10 +98,7 @@ public class PiSDFMergeabilty {
     }
 
     // Compute cluster repetition
-    List<AbstractActor> actorList = new LinkedList<>();
-    actorList.add(x);
-    actorList.add(y);
-    long clusterRepetition = MathFunctionsHelper.gcd(CollectionUtil.mapGetAll(brv, actorList));
+    long clusterRepetition = MathFunctionsHelper.gcd(CollectionUtil.mapGetAll(brv, Arrays.asList(x, y)));
 
     boolean result = true;
     boolean delayInside = false;

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiSDFMergeabilty.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiSDFMergeabilty.java
@@ -40,8 +40,9 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.math3.util.ArithmeticUtils;
+import org.preesm.commons.CollectionUtil;
 import org.preesm.commons.exceptions.PreesmRuntimeException;
+import org.preesm.commons.math.MathFunctionsHelper;
 import org.preesm.model.pisdf.AbstractActor;
 import org.preesm.model.pisdf.AbstractVertex;
 import org.preesm.model.pisdf.DataInputPort;
@@ -62,35 +63,6 @@ import org.preesm.model.pisdf.util.topology.PiSDFTopologyHelper;
  *
  */
 public class PiSDFMergeabilty {
-
-  /**
-   * Used to get great common divisor repetition count of a list of actors
-   * 
-   * @param actorList
-   *          actor to compute gcd repetition from
-   * @param repetitionVector
-   *          repetition vector of corresponding graph
-   * 
-   * @return gcd repetition count
-   */
-  public static final long computeGcdRepetition(List<AbstractActor> actorList,
-      Map<AbstractVertex, Long> repetitionVector) {
-    // Retrieve all repetition value
-    List<Long> actorsRepetition = new LinkedList<>();
-    for (AbstractActor a : actorList) {
-      if (repetitionVector.containsKey(a)) {
-        actorsRepetition.add(repetitionVector.get(a));
-      } else {
-        throw new PreesmRuntimeException("ClusteringHelper: Repetition vector does not contains key of " + a.getName());
-      }
-    }
-    // Compute gcd
-    long clusterRepetition = actorsRepetition.get(0);
-    for (int i = 1; i < actorsRepetition.size(); i++) {
-      clusterRepetition = ArithmeticUtils.gcd(clusterRepetition, actorsRepetition.get(i));
-    }
-    return clusterRepetition;
-  }
 
   /**
    * 
@@ -125,10 +97,10 @@ public class PiSDFMergeabilty {
     }
 
     // Compute cluster repetition
-    List<AbstractActor> actorList = new LinkedList<>();
+    List<AbstractVertex> actorList = new LinkedList<>();
     actorList.add(x);
     actorList.add(y);
-    long clusterRepetition = computeGcdRepetition(actorList, brv);
+    long clusterRepetition = MathFunctionsHelper.gcd(CollectionUtil.mapGetAll(brv, actorList));
 
     boolean result = true;
     boolean delayInside = false;

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiSDFMergeabilty.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiSDFMergeabilty.java
@@ -158,7 +158,7 @@ public class PiSDFMergeabilty {
    * @return true if the couple does not introduce cycle
    */
   public static boolean isCycleIntroductionConditionValid(final AbstractActor x, final AbstractActor y) {
-    return !PiSDFTopologyHelper.isMoreThanOneSimplePath(x, y);
+    return !PiSDFTopologyHelper.isThereIsALongPath(x, y);
   }
 
   /**

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiSDFMergeabilty.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiSDFMergeabilty.java
@@ -97,7 +97,7 @@ public class PiSDFMergeabilty {
     }
 
     // Compute cluster repetition
-    List<AbstractVertex> actorList = new LinkedList<>();
+    List<AbstractActor> actorList = new LinkedList<>();
     actorList.add(x);
     actorList.add(y);
     long clusterRepetition = MathFunctionsHelper.gcd(CollectionUtil.mapGetAll(brv, actorList));

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/IsThereALongPathSwitch.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/IsThereALongPathSwitch.java
@@ -1,0 +1,66 @@
+package org.preesm.model.pisdf.util.topology;
+
+import org.preesm.model.pisdf.AbstractActor;
+import org.preesm.model.pisdf.DataOutputPort;
+import org.preesm.model.pisdf.Fifo;
+import org.preesm.model.pisdf.PiGraph;
+
+/**
+ * @author dgageot
+ *
+ *         A long path is defined as a path that encounters more than one Fifo
+ *
+ */
+public class IsThereALongPathSwitch extends PiSDFSuccessorSwitch {
+
+  private final AbstractActor potentialSucc;
+  private long                fifoCount;
+
+  /**
+   * @author dgageot
+   */
+  static class ThereIsALongPath extends RuntimeException {
+    private static final long serialVersionUID = 8123950588521527792L;
+  }
+
+  public IsThereALongPathSwitch(final AbstractActor potentialSucc) {
+    this.potentialSucc = potentialSucc;
+    this.fifoCount = 0;
+  }
+
+  @Override
+  public Boolean caseAbstractActor(final AbstractActor actor) {
+    // If we reached the target
+    if (actor.equals(this.potentialSucc)) {
+      if (this.fifoCount > 1) {
+        throw new ThereIsALongPath();
+      }
+      return false;
+    }
+
+    if (!this.visitedElements.contains(actor)) {
+      this.visitedElements.add(actor);
+      long tempFifoCount = this.fifoCount;
+      for (DataOutputPort dop : actor.getDataOutputPorts()) {
+        this.fifoCount = tempFifoCount;
+        doSwitch(dop);
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public Boolean caseFifo(final Fifo fifo) {
+    // If there is a delay on fifo, stop here
+    if (fifo.getDelay() != null) {
+      return true;
+    }
+    this.fifoCount = this.fifoCount + 1;
+    return super.caseFifo(fifo);
+  }
+
+  @Override
+  public Boolean casePiGraph(final PiGraph graph) {
+    return caseAbstractActor(graph);
+  }
+}

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/IsThereALongPathSwitch.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/IsThereALongPathSwitch.java
@@ -8,10 +8,15 @@ import org.preesm.model.pisdf.PiGraph;
 /**
  * @author dgageot
  *
- *         A long path is defined as a path that encounters more than one Fifo
+ *         Package visible helper switch that throws a {@link ThereIsALongPathException} when an actor equals to the
+ *         local attribute 'potentialSucc' is encountered while visiting the successors of the subject of the switch and
+ *         the path is strictly longer than 1. See
+ *         {@link PiSDFTopologyHelper#isThereIsALongPath(AbstractActor, AbstractActor)} for usage.
+ *
+ *         A long path is defined as a path that encounters more than one Fifo.
  *
  */
-public class IsThereALongPathSwitch extends PiSDFSuccessorSwitch {
+class IsThereALongPathSwitch extends PiSDFSuccessorSwitch {
 
   private final AbstractActor potentialSucc;
   private long                fifoCount;
@@ -19,11 +24,11 @@ public class IsThereALongPathSwitch extends PiSDFSuccessorSwitch {
   /**
    * @author dgageot
    */
-  static class ThereIsALongPath extends RuntimeException {
+  static class ThereIsALongPathException extends RuntimeException {
     private static final long serialVersionUID = 8123950588521527792L;
   }
 
-  public IsThereALongPathSwitch(final AbstractActor potentialSucc) {
+  IsThereALongPathSwitch(final AbstractActor potentialSucc) {
     this.potentialSucc = potentialSucc;
     this.fifoCount = 0;
   }
@@ -33,7 +38,7 @@ public class IsThereALongPathSwitch extends PiSDFSuccessorSwitch {
     // If we reached the target
     if (actor.equals(this.potentialSucc)) {
       if (this.fifoCount > 1) {
-        throw new ThereIsALongPath();
+        throw new ThereIsALongPathException();
       }
       return false;
     }

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/PiSDFPredecessorSwitch.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/PiSDFPredecessorSwitch.java
@@ -127,6 +127,10 @@ public abstract class PiSDFPredecessorSwitch extends PiMMSwitch<Boolean> {
    *
    * @author anmorvan
    *
+   *         Package visible helper switch that throws a {@link PredecessorFoundException} when an actor equals to the
+   *         local attribute is encountered while visiting the predecessors of the subject of the switch. See
+   *         {@link PiSDFTopologyHelper#isPredecessor(AbstractActor, AbstractActor)} for usage.
+   *
    */
   static class IsPredecessorSwitch extends PiSDFPredecessorSwitch {
     private final AbstractActor potentialPred;

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/PiSDFSuccessorSwitch.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/PiSDFSuccessorSwitch.java
@@ -114,6 +114,15 @@ public abstract class PiSDFSuccessorSwitch extends PiMMSwitch<Boolean> {
 
   /**
    *
+   * @author dgageot
+   *
+   */
+  static class MoreThanOneSimplePathException extends RuntimeException {
+    private static final long serialVersionUID = 8123950588521527792L;
+  }
+
+  /**
+   *
    * @author anmorvan
    *
    */
@@ -130,6 +139,43 @@ public abstract class PiSDFSuccessorSwitch extends PiMMSwitch<Boolean> {
         throw new SuccessorFoundException();
       }
       return super.caseAbstractActor(actor);
+    }
+
+  }
+
+  /**
+   *
+   * @author dgageot
+   *
+   */
+  static class IsMoreThanOneSimplePathSwitch extends PiSDFSuccessorSwitch {
+    private final AbstractActor potentialSucc;
+
+    private long pathCount;
+
+    public IsMoreThanOneSimplePathSwitch(final AbstractActor potentialSucc) {
+      this.potentialSucc = potentialSucc;
+      this.pathCount = 0;
+    }
+
+    @Override
+    public Boolean caseAbstractActor(final AbstractActor actor) {
+      if (actor.equals(this.potentialSucc)) {
+        this.pathCount = this.pathCount + 1;
+        if (this.pathCount > 1) {
+          throw new MoreThanOneSimplePathException();
+        }
+      }
+      return super.caseAbstractActor(actor);
+    }
+
+    @Override
+    public Boolean caseFifo(final Fifo fifo) {
+      // If there is a delay on fifo, stop here
+      if (fifo.getDelay() != null) {
+        return true;
+      }
+      return super.caseFifo(fifo);
     }
 
   }

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/PiSDFSuccessorSwitch.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/PiSDFSuccessorSwitch.java
@@ -116,6 +116,10 @@ public abstract class PiSDFSuccessorSwitch extends PiMMSwitch<Boolean> {
    *
    * @author anmorvan
    *
+   *         Package visible helper switch that throws a {@link SuccessorFoundException} when an actor equals to the
+   *         local attribute is encountered while visiting the successors of the subject of the switch. See
+   *         {@link PiSDFTopologyHelper#isSuccessor(AbstractActor, AbstractActor)} for usage.
+   *
    */
   static class IsSuccessorSwitch extends PiSDFSuccessorSwitch {
     private final AbstractActor potentialPred;

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/PiSDFSuccessorSwitch.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/PiSDFSuccessorSwitch.java
@@ -114,15 +114,6 @@ public abstract class PiSDFSuccessorSwitch extends PiMMSwitch<Boolean> {
 
   /**
    *
-   * @author dgageot
-   *
-   */
-  static class MoreThanOneSimplePathException extends RuntimeException {
-    private static final long serialVersionUID = 8123950588521527792L;
-  }
-
-  /**
-   *
    * @author anmorvan
    *
    */
@@ -139,57 +130,6 @@ public abstract class PiSDFSuccessorSwitch extends PiMMSwitch<Boolean> {
         throw new SuccessorFoundException();
       }
       return super.caseAbstractActor(actor);
-    }
-
-  }
-
-  /**
-   *
-   * @author dgageot
-   *
-   */
-  static class IsMoreThanOneSimplePathSwitch extends PiSDFSuccessorSwitch {
-    private final AbstractActor potentialSucc;
-
-    private long fifoCount;
-
-    public IsMoreThanOneSimplePathSwitch(final AbstractActor potentialSucc) {
-      this.potentialSucc = potentialSucc;
-      this.fifoCount = 0;
-    }
-
-    @Override
-    public Boolean caseAbstractActor(final AbstractActor actor) {
-      if (actor.equals(this.potentialSucc)) {
-        if (this.fifoCount > 1) {
-          throw new MoreThanOneSimplePathException();
-        }
-        return true;
-      }
-      if (!this.visitedElements.contains(actor)) {
-        this.visitedElements.add(actor);
-        long tempFifoCount = this.fifoCount;
-        for (DataOutputPort dop : actor.getDataOutputPorts()) {
-          this.fifoCount = tempFifoCount;
-          doSwitch(dop);
-        }
-      }
-      return true;
-    }
-
-    @Override
-    public Boolean caseFifo(final Fifo fifo) {
-      // If there is a delay on fifo, stop here
-      if (fifo.getDelay() != null) {
-        return true;
-      }
-      this.fifoCount = this.fifoCount + 1;
-      return super.caseFifo(fifo);
-    }
-
-    @Override
-    public Boolean casePiGraph(final PiGraph graph) {
-      return caseAbstractActor(graph);
     }
 
   }

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/PiSDFTopologyHelper.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/PiSDFTopologyHelper.java
@@ -39,7 +39,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import org.preesm.model.pisdf.AbstractActor;
-import org.preesm.model.pisdf.util.topology.IsThereALongPathSwitch.ThereIsALongPath;
+import org.preesm.model.pisdf.util.topology.IsThereALongPathSwitch.ThereIsALongPathException;
 import org.preesm.model.pisdf.util.topology.PiSDFPredecessorSwitch.IsPredecessorSwitch;
 import org.preesm.model.pisdf.util.topology.PiSDFPredecessorSwitch.PredecessorFoundException;
 import org.preesm.model.pisdf.util.topology.PiSDFSuccessorSwitch.IsSuccessorSwitch;
@@ -111,13 +111,14 @@ public class PiSDFTopologyHelper {
   }
 
   /**
-   * returns true if there is more than one simple path to get from potential successor to target
+   * Returns true if there is a long path from potentialSucc to target. A long path is defined as a path that encounters
+   * more than one Fifo.
    */
   public static final boolean isThereIsALongPath(final AbstractActor potentialSucc, final AbstractActor target) {
     try {
       new IsThereALongPathSwitch(target).doSwitch(potentialSucc);
       return false;
-    } catch (final ThereIsALongPath e) {
+    } catch (final ThereIsALongPathException e) {
       return true;
     }
   }

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/PiSDFTopologyHelper.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/PiSDFTopologyHelper.java
@@ -39,11 +39,10 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import org.preesm.model.pisdf.AbstractActor;
+import org.preesm.model.pisdf.util.topology.IsThereALongPathSwitch.ThereIsALongPath;
 import org.preesm.model.pisdf.util.topology.PiSDFPredecessorSwitch.IsPredecessorSwitch;
 import org.preesm.model.pisdf.util.topology.PiSDFPredecessorSwitch.PredecessorFoundException;
-import org.preesm.model.pisdf.util.topology.PiSDFSuccessorSwitch.IsMoreThanOneSimplePathSwitch;
 import org.preesm.model.pisdf.util.topology.PiSDFSuccessorSwitch.IsSuccessorSwitch;
-import org.preesm.model.pisdf.util.topology.PiSDFSuccessorSwitch.MoreThanOneSimplePathException;
 import org.preesm.model.pisdf.util.topology.PiSDFSuccessorSwitch.SuccessorFoundException;
 
 /**
@@ -114,11 +113,11 @@ public class PiSDFTopologyHelper {
   /**
    * returns true if there is more than one simple path to get from potential successor to target
    */
-  public static final boolean isMoreThanOneSimplePath(final AbstractActor potentialSucc, final AbstractActor target) {
+  public static final boolean isThereIsALongPath(final AbstractActor potentialSucc, final AbstractActor target) {
     try {
-      new IsMoreThanOneSimplePathSwitch(target).doSwitch(potentialSucc);
+      new IsThereALongPathSwitch(target).doSwitch(potentialSucc);
       return false;
-    } catch (final MoreThanOneSimplePathException e) {
+    } catch (final ThereIsALongPath e) {
       return true;
     }
   }

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/PiSDFTopologyHelper.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/topology/PiSDFTopologyHelper.java
@@ -41,7 +41,9 @@ import java.util.List;
 import org.preesm.model.pisdf.AbstractActor;
 import org.preesm.model.pisdf.util.topology.PiSDFPredecessorSwitch.IsPredecessorSwitch;
 import org.preesm.model.pisdf.util.topology.PiSDFPredecessorSwitch.PredecessorFoundException;
+import org.preesm.model.pisdf.util.topology.PiSDFSuccessorSwitch.IsMoreThanOneSimplePathSwitch;
 import org.preesm.model.pisdf.util.topology.PiSDFSuccessorSwitch.IsSuccessorSwitch;
+import org.preesm.model.pisdf.util.topology.PiSDFSuccessorSwitch.MoreThanOneSimplePathException;
 import org.preesm.model.pisdf.util.topology.PiSDFSuccessorSwitch.SuccessorFoundException;
 
 /**
@@ -84,7 +86,7 @@ public class PiSDFTopologyHelper {
   }
 
   /**
-   * Used to get actors connected in input a specified PiSDF actor
+   * Used to get actors connected in input of a specified PiSDF actor
    *
    * @param a
    *          actor
@@ -110,58 +112,15 @@ public class PiSDFTopologyHelper {
   }
 
   /**
-   * Used to get all predecessors of a specified PiSDF actor
-   *
-   * @param a
-   *          actor
-   * @return predecessors of actor a
+   * returns true if there is more than one simple path to get from potential successor to target
    */
-  public static final List<AbstractActor> getPredecessors(final AbstractActor a) {
-    List<AbstractActor> result = new ArrayList<>();
-    List<AbstractActor> tmp = getDirectPredecessorsOf(a);
-    boolean exit = false;
-    do {
-      // avoid cycles deadlock
-      tmp.removeAll(result);
-      result.addAll(tmp);
-      final List<AbstractActor> tmp1 = new ArrayList<>();
-      tmp1.addAll(tmp);
-      if (tmp.isEmpty()) {
-        exit = true;
-      }
-      tmp.clear();
-      for (final AbstractActor e : tmp1) {
-        tmp.addAll(getDirectPredecessorsOf(e));
-      }
-    } while (!exit);
-    return result;
+  public static final boolean isMoreThanOneSimplePath(final AbstractActor potentialSucc, final AbstractActor target) {
+    try {
+      new IsMoreThanOneSimplePathSwitch(target).doSwitch(potentialSucc);
+      return false;
+    } catch (final MoreThanOneSimplePathException e) {
+      return true;
+    }
   }
 
-  /**
-   * Used to get all successors of a specified PiSDF actor
-   *
-   * @param a
-   *          actor
-   * @return successors of actor a
-   */
-  public static final List<AbstractActor> getSuccessors(final AbstractActor a) {
-    List<AbstractActor> result = new ArrayList<>();
-    List<AbstractActor> tmp = getDirectSuccessorsOf(a);
-    boolean exit = false;
-    do {
-      // avoid cycles deadlock
-      tmp.removeAll(result);
-      result.addAll(tmp);
-      final List<AbstractActor> tmp1 = new ArrayList<>();
-      tmp1.addAll(tmp);
-      if (tmp.isEmpty()) {
-        exit = true;
-      }
-      tmp.clear();
-      for (final AbstractActor e : tmp1) {
-        tmp.addAll(getDirectSuccessorsOf(e));
-      }
-    } while (!exit);
-    return result;
-  }
 }

--- a/release_notes.md
+++ b/release_notes.md
@@ -25,6 +25,7 @@ PREESM Changelog
 * SPiDER codegen considers empty PAPIFY configs as papify=false;
 * Update round buffer memory script to handle multiple inputs;
 * Schedule: Add an interface to perform transform
+* PiSDF: Add more rules to check mergeability, remove getDirectPred/Succ and getPred/Succ
 * Codegen:
   * Add IteratedBuffer, ClusterBlock, SectionBlock for clustering codegen
   * Add conditional "#pragma omp parallel for" on FiniteLoopBlock

--- a/release_notes.md
+++ b/release_notes.md
@@ -25,7 +25,7 @@ PREESM Changelog
 * SPiDER codegen considers empty PAPIFY configs as papify=false;
 * Update round buffer memory script to handle multiple inputs;
 * Schedule: Add an interface to perform transform
-* PiSDF: Add more rules to check mergeability, remove getDirectPred/Succ and getPred/Succ
+* PiSDF: Add more rules to check mergeability, remove getPreds/Succs from TopologyHelper
 * Codegen:
   * Add IteratedBuffer, ClusterBlock, SectionBlock for clustering codegen
   * Add conditional "#pragma omp parallel for" on FiniteLoopBlock


### PR DESCRIPTION
I've added 3 new conditions to check mergeability, according to the theorem of J. L. Pino on clustering constraints:

- No hidden delay
- No cycle introduction
- Precedence shift from actor A to B
- Precedence shift from actor B to A

I've removed method to ensures the cycle introduction and replaced them with a derivative of PiSDFSuccessorSwitch (IsMoreThanOneSimplePath).