### PR TITLE
(Codegen) Model enhancement for clustering

### DIFF
--- a/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/DevelopperPrinter.xtend
+++ b/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/DevelopperPrinter.xtend
@@ -69,6 +69,7 @@ import org.preesm.codegen.model.Variable
 import org.preesm.codegen.printer.CodegenAbstractPrinter
 import org.preesm.codegen.model.DistributedMemoryCommunication
 import org.preesm.codegen.model.PapifyFunctionCall
+import org.preesm.codegen.model.IteratedBuffer
 
 /**
  * This {@link DevelopperPrinter} is a dummy implementation of the
@@ -201,6 +202,8 @@ class DevelopperPrinter extends CodegenAbstractPrinter {
 	override printBufferIteratorDeclaration(BufferIterator bufferIterator) '''<BufferIterator_Declaration>'''
 
 	override printBufferIteratorDefinition(BufferIterator bufferIterator) '''<BufferIterator_Definition>'''
+	
+	override printIteratedBuffer(IteratedBuffer iteratedBuffer) '''<IteratedBuffer>'''
 	
 	override printDataTansfer(DataTransferAction action) '''<Data_Transfer>'''
 	

--- a/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/DevelopperPrinter.xtend
+++ b/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/DevelopperPrinter.xtend
@@ -71,6 +71,7 @@ import org.preesm.codegen.model.DistributedMemoryCommunication
 import org.preesm.codegen.model.PapifyFunctionCall
 import org.preesm.codegen.model.IteratedBuffer
 import org.preesm.codegen.model.ClusterBlock
+import org.preesm.codegen.model.SectionBlock
 
 /**
  * This {@link DevelopperPrinter} is a dummy implementation of the
@@ -175,6 +176,10 @@ class DevelopperPrinter extends CodegenAbstractPrinter {
 	override printClusterBlockFooter(ClusterBlock block) '''<Cluster_Block_Foot>'''
 
 	override printClusterBlockHeader(ClusterBlock block) '''<Cluster_Block_Head>'''
+	
+	override printSectionBlockFooter(SectionBlock block) '''<Section_Block_Foot>'''
+
+	override printSectionBlockHeader(SectionBlock block) '''<Section_Block_Head>'''
 
 	override printNullBuffer(NullBuffer nullBuffer) '''<NullBuffer>'''
 

--- a/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/DevelopperPrinter.xtend
+++ b/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/DevelopperPrinter.xtend
@@ -70,6 +70,7 @@ import org.preesm.codegen.printer.CodegenAbstractPrinter
 import org.preesm.codegen.model.DistributedMemoryCommunication
 import org.preesm.codegen.model.PapifyFunctionCall
 import org.preesm.codegen.model.IteratedBuffer
+import org.preesm.codegen.model.ClusterBlock
 
 /**
  * This {@link DevelopperPrinter} is a dummy implementation of the
@@ -170,6 +171,10 @@ class DevelopperPrinter extends CodegenAbstractPrinter {
 	override printFiniteLoopBlockFooter(FiniteLoopBlock block) '''<Finite_Loop_Block_Foot>'''
 
 	override printFiniteLoopBlockHeader(FiniteLoopBlock block) '''<Finite_Loop_Block_Head>'''
+
+	override printClusterBlockFooter(ClusterBlock block) '''<Cluster_Block_Foot>'''
+
+	override printClusterBlockHeader(ClusterBlock block) '''<Cluster_Block_Head>'''
 
 	override printNullBuffer(NullBuffer nullBuffer) '''<NullBuffer>'''
 

--- a/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
+++ b/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
@@ -84,6 +84,7 @@ import org.preesm.commons.exceptions.PreesmRuntimeException
 import org.preesm.commons.files.PreesmResourcesHelper
 import org.preesm.model.pisdf.util.CHeaderUsedLocator
 import org.preesm.codegen.model.IteratedBuffer
+import org.preesm.codegen.model.ClusterBlock
 
 /**
  * This printer is currently used to print C code only for GPP processors
@@ -233,6 +234,18 @@ class CPrinter extends DefaultPrinter {
 			}
 		}
 	'''
+
+	override printClusterBlockHeader(ClusterBlock block) '''
+		// Cluster: «block.name»
+		// Schedule: «block.schedule»
+		{
+			
+			'''
+
+	override printClusterBlockFooter(ClusterBlock block) '''
+		}
+	'''
+
 
 	override String printFifoCall(FifoCall fifoCall) {
 		var result = "fifo" + fifoCall.operation.toString.toLowerCase.toFirstUpper + "("

--- a/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
+++ b/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
@@ -85,6 +85,7 @@ import org.preesm.commons.files.PreesmResourcesHelper
 import org.preesm.model.pisdf.util.CHeaderUsedLocator
 import org.preesm.codegen.model.IteratedBuffer
 import org.preesm.codegen.model.ClusterBlock
+import org.preesm.codegen.model.SectionBlock
 
 /**
  * This printer is currently used to print C code only for GPP processors
@@ -241,6 +242,9 @@ class CPrinter extends DefaultPrinter {
 	override printClusterBlockHeader(ClusterBlock block) '''
 		// Cluster: «block.name»
 		// Schedule: «block.schedule»
+		«IF block.parallel.equals(true)»
+		#pragma omp parallel sections
+		«ENDIF»
 		{
 			
 			'''
@@ -249,6 +253,15 @@ class CPrinter extends DefaultPrinter {
 		}
 	'''
 
+	override printSectionBlockHeader(SectionBlock block) '''
+		#pragma omp section
+		{
+			
+			'''
+
+	override printSectionBlockFooter(SectionBlock block) '''
+		}
+	'''
 
 	override String printFifoCall(FifoCall fifoCall) {
 		var result = "fifo" + fifoCall.operation.toString.toLowerCase.toFirstUpper + "("

--- a/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
+++ b/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
@@ -667,7 +667,7 @@ class CPrinter extends DefaultPrinter {
 
 	override printBufferIteratorDefinition(BufferIterator bufferIterator) ''''''
 
-	override printIteratedBuffer(IteratedBuffer iteratedBuffer) '''«doSwitch(iteratedBuffer.buffer)» + «printIntVar(iteratedBuffer.iter)» * «iteratedBuffer.iterSize»'''
+	override printIteratedBuffer(IteratedBuffer iteratedBuffer) '''«doSwitch(iteratedBuffer.buffer)» + «printIntVar(iteratedBuffer.iter)» * «iteratedBuffer.size»'''
 
 	override printIntVar(IntVar intVar) '''«intVar.name»'''
 

--- a/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
+++ b/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
@@ -221,17 +221,16 @@ class CPrinter extends DefaultPrinter {
 
 	//#pragma omp parallel for private(«block2.iter.name»)
 	override printFiniteLoopBlockHeader(FiniteLoopBlock block2) '''
-
 		// Begin the for loop
 		{
 			int «block2.iter.name»;
-			for(«block2.iter.name»=0;«block2.iter.name»<«block2.nbIter»;«block2.iter.name»++){
-
-	'''
+			for(«block2.iter.name»=0;«block2.iter.name»<«block2.nbIter»;«block2.iter.name»++) {
+				
+				'''
 
 	override printFiniteLoopBlockFooter(FiniteLoopBlock block2) '''
+			}
 		}
-	}
 	'''
 
 	override String printFifoCall(FifoCall fifoCall) {

--- a/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
+++ b/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
@@ -226,6 +226,9 @@ class CPrinter extends DefaultPrinter {
 		// Begin the for loop
 		{
 			int «block2.iter.name»;
+			«IF block2.parallel.equals(true)»
+			#pragma omp parallel for private(«block2.iter.name»)
+			«ENDIF»
 			for(«block2.iter.name»=0;«block2.iter.name»<«block2.nbIter»;«block2.iter.name»++) {
 				
 				'''

--- a/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
+++ b/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
@@ -83,6 +83,7 @@ import org.preesm.codegen.printer.DefaultPrinter
 import org.preesm.commons.exceptions.PreesmRuntimeException
 import org.preesm.commons.files.PreesmResourcesHelper
 import org.preesm.model.pisdf.util.CHeaderUsedLocator
+import org.preesm.codegen.model.IteratedBuffer
 
 /**
  * This printer is currently used to print C code only for GPP processors
@@ -636,6 +637,8 @@ class CPrinter extends DefaultPrinter {
 	override printBufferIteratorDeclaration(BufferIterator bufferIterator) ''''''
 
 	override printBufferIteratorDefinition(BufferIterator bufferIterator) ''''''
+
+	override printIteratedBuffer(IteratedBuffer iteratedBuffer) '''«doSwitch(iteratedBuffer.buffer)» + «printIntVar(iteratedBuffer.iter)» * «iteratedBuffer.iterSize»'''
 
 	override printIntVar(IntVar intVar) '''«intVar.name»'''
 

--- a/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/MPPA2ClusterPrinter.xtend
+++ b/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/MPPA2ClusterPrinter.xtend
@@ -264,16 +264,15 @@ class MPPA2ClusterPrinter extends DefaultPrinter {
 			if(block2.nbIter > 1 && this.sharedOnly == 0){
 				gets += "#pragma omp parallel for private(" + block2.iter.name + ")\n"
 			}
-			gets += "for(" + block2.iter.name + "=0;" + block2.iter.name +"<" + block2.nbIter + ";" + block2.iter.name + "++){\n"
+			gets += "for(" + block2.iter.name + "=0;" + block2.iter.name +"<" + block2.nbIter + ";" + block2.iter.name + "++) {"
 
 			if(local_offset > local_buffer_size)
 				local_buffer_size = local_offset
 	gets}»
-
-	'''
+			
+			'''
 
 	override printFiniteLoopBlockFooter(FiniteLoopBlock block2) '''
-
 			}// End the for loop
 		«{
 				var puts = ""

--- a/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/MPPA2IOPrinter.xtend
+++ b/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/MPPA2IOPrinter.xtend
@@ -197,16 +197,15 @@ class MPPA2IOPrinter extends MPPA2ClusterPrinter {
 			if(block2.nbIter > 1 && this.sharedOnly == 0){
 				gets += "#pragma omp parallel for private(" + block2.iter.name + ")\n"
 			}
-			gets += "for(" + block2.iter.name + "=0;" + block2.iter.name +"<" + block2.nbIter + ";" + block2.iter.name + "++){\n"
+			gets += "for(" + block2.iter.name + "=0;" + block2.iter.name +"<" + block2.nbIter + ";" + block2.iter.name + "++) {"
 
 			if(local_offset > local_buffer_size)
 				local_buffer_size = local_offset
 	gets}»
-
-	'''
+			
+			'''
 
 	override printFiniteLoopBlockFooter(FiniteLoopBlock block2) '''
-
 			}// End the for loop
 		«{
 				var puts = ""

--- a/plugins/org.preesm.codegen/model/Codegen.xcore
+++ b/plugins/org.preesm.codegen/model/Codegen.xcore
@@ -324,8 +324,6 @@ class BufferIterator extends SubBuffer {
 class IteratedBuffer extends Buffer {
 	refers Buffer buffer
 	refers IntVar iter
-	long iterSize
-	
 }
 
 class PapifyAction extends Variable {

--- a/plugins/org.preesm.codegen/model/Codegen.xcore
+++ b/plugins/org.preesm.codegen/model/Codegen.xcore
@@ -203,6 +203,10 @@ class CoreBlock extends Block {
 
 class ClusterBlock extends Block {
 	String schedule
+	boolean parallel
+}
+
+class SectionBlock extends Block {
 }
 
 class ActorBlock extends Block {

--- a/plugins/org.preesm.codegen/model/Codegen.xcore
+++ b/plugins/org.preesm.codegen/model/Codegen.xcore
@@ -312,6 +312,13 @@ class BufferIterator extends SubBuffer {
 	refers IntVar iter
 }
 
+class IteratedBuffer extends Buffer {
+	refers Buffer buffer
+	refers IntVar iter
+	long iterSize
+	
+}
+
 class PapifyAction extends Variable {
 	boolean opening = "false"
 	boolean closing = "false"

--- a/plugins/org.preesm.codegen/model/Codegen.xcore
+++ b/plugins/org.preesm.codegen/model/Codegen.xcore
@@ -201,6 +201,10 @@ class CoreBlock extends Block {
 	unordered id int coreID
 }
 
+class ClusterBlock extends Block {
+	String schedule
+}
+
 class ActorBlock extends Block {
 	refers LoopBlock loopBlock
 	refers CallBlock initBlock

--- a/plugins/org.preesm.codegen/model/Codegen.xcore
+++ b/plugins/org.preesm.codegen/model/Codegen.xcore
@@ -303,6 +303,7 @@ type range wraps org.preesm.algorithm.memory.script.Range
 
 class FiniteLoopBlock extends LoopBlock {
 	int nbIter
+	boolean parallel
 	refers IntVar iter
 	refers BufferIterator[] inBuffers
 	refers BufferIterator[] outBuffers

--- a/plugins/org.preesm.codegen/src/org/preesm/codegen/printer/CodegenAbstractPrinter.java
+++ b/plugins/org.preesm.codegen/src/org/preesm/codegen/printer/CodegenAbstractPrinter.java
@@ -699,6 +699,14 @@ public abstract class CodegenAbstractPrinter extends CodegenSwitch<CharSequence>
       hasNewLine = false;
     }
 
+    final EList<Variable> variables = clusterBlock.getDefinitions();
+    for (final Variable variable : variables) {
+      if (variable instanceof Buffer) {
+        final CharSequence code = printBufferDefinition((Buffer) variable);
+        result.append(code, indentation);
+      }
+    }
+
     // Visit all codeElements
     final EList<CodeElt> codeElts = clusterBlock.getCodeElts();
     for (final CodeElt codeElt : codeElts) {

--- a/plugins/org.preesm.codegen/src/org/preesm/codegen/printer/CodegenAbstractPrinter.java
+++ b/plugins/org.preesm.codegen/src/org/preesm/codegen/printer/CodegenAbstractPrinter.java
@@ -72,6 +72,7 @@ import org.preesm.codegen.model.OutputDataTransfer;
 import org.preesm.codegen.model.PapifyAction;
 import org.preesm.codegen.model.PapifyFunctionCall;
 import org.preesm.codegen.model.RegisterSetUpAction;
+import org.preesm.codegen.model.SectionBlock;
 import org.preesm.codegen.model.SharedMemoryCommunication;
 import org.preesm.codegen.model.SpecialCall;
 import org.preesm.codegen.model.SpecialType;
@@ -715,6 +716,39 @@ public abstract class CodegenAbstractPrinter extends CodegenSwitch<CharSequence>
   }
 
   @Override
+  public CharSequence caseSectionBlock(final SectionBlock sectionBlock) {
+    StringConcatenation result = new StringConcatenation();
+    String indentation = "";
+    boolean hasNewLine;
+
+    final CharSequence sectionBlockheader = printSectionBlockHeader(sectionBlock);
+    result.append(sectionBlockheader, indentation);
+
+    if (sectionBlockheader.length() > 0) {
+      indentation = CodegenAbstractPrinter.getLastLineIndentation(result);
+      result = CodegenAbstractPrinter.trimLastEOL(result);
+      hasNewLine = CodegenAbstractPrinter.endWithEOL(result);
+    } else {
+      hasNewLine = false;
+    }
+
+    // Visit all codeElements
+    final EList<CodeElt> codeElts = sectionBlock.getCodeElts();
+    for (final CodeElt codeElt : codeElts) {
+      final CharSequence code = doSwitch(codeElt);
+      result.append(code, indentation);
+    }
+
+    if (hasNewLine) {
+      result.newLineIfNotEmpty();
+    }
+
+    result.append(printSectionBlockFooter(sectionBlock), "");
+
+    return result;
+  }
+
+  @Override
   public CharSequence caseNullBuffer(final NullBuffer nullBuffer) {
     if (this.state.equals(PrinterState.PRINTING_DEFINITIONS)) {
       return printNullBufferDefinition(nullBuffer);
@@ -1187,6 +1221,24 @@ public abstract class CodegenAbstractPrinter extends CodegenSwitch<CharSequence>
    * @return the printed {@link CharSequence}
    */
   public abstract CharSequence printClusterBlockHeader(ClusterBlock block);
+
+  /**
+   * Method called after printing all {@link CodeElt} belonging to a {@link SectionBlock}.
+   *
+   * @param block
+   *          the {@link SectionBlock} whose {@link CodeElt} were printed before calling this method.
+   * @return the printed {@link CharSequence}
+   */
+  public abstract CharSequence printSectionBlockFooter(SectionBlock block);
+
+  /**
+   * Method called before printing all {@link CodeElt} belonging to a {@link SectionBlock}.
+   *
+   * @param block
+   *          the {@link SectionBlock} whose {@link CodeElt} will be printed after calling this method.
+   * @return the printed {@link CharSequence}
+   */
+  public abstract CharSequence printSectionBlockHeader(SectionBlock block);
 
   /**
    * Method called to print a {@link NullBuffer} outside the {@link CoreBlock#getDefinitions() definition} or the

--- a/plugins/org.preesm.codegen/src/org/preesm/codegen/printer/CodegenAbstractPrinter.java
+++ b/plugins/org.preesm.codegen/src/org/preesm/codegen/printer/CodegenAbstractPrinter.java
@@ -672,7 +672,6 @@ public abstract class CodegenAbstractPrinter extends CodegenSwitch<CharSequence>
 
     if (hasNewLine) {
       result.newLineIfNotEmpty();
-      result.append(indentation);
     }
 
     result.append(printFiniteLoopBlockFooter(loopBlock), "");

--- a/plugins/org.preesm.codegen/src/org/preesm/codegen/printer/CodegenAbstractPrinter.java
+++ b/plugins/org.preesm.codegen/src/org/preesm/codegen/printer/CodegenAbstractPrinter.java
@@ -64,6 +64,7 @@ import org.preesm.codegen.model.FreeDataTransferBuffer;
 import org.preesm.codegen.model.FunctionCall;
 import org.preesm.codegen.model.GlobalBufferDeclaration;
 import org.preesm.codegen.model.IntVar;
+import org.preesm.codegen.model.IteratedBuffer;
 import org.preesm.codegen.model.LoopBlock;
 import org.preesm.codegen.model.NullBuffer;
 import org.preesm.codegen.model.OutputDataTransfer;
@@ -741,6 +742,11 @@ public abstract class CodegenAbstractPrinter extends CodegenSwitch<CharSequence>
   }
 
   @Override
+  public CharSequence caseIteratedBuffer(final IteratedBuffer iteratedBuffer) {
+    return printIteratedBuffer(iteratedBuffer);
+  }
+
+  @Override
   public CharSequence caseDataTransferAction(DataTransferAction object) {
     return printDataTansfer(object);
   }
@@ -1237,6 +1243,16 @@ public abstract class CodegenAbstractPrinter extends CodegenSwitch<CharSequence>
    * @return the printed {@link CharSequence}
    */
   public abstract CharSequence printBufferIterator(BufferIterator bufferIterator);
+
+  /**
+   * Method called to print a {@link IteratedBuffer} outside the {@link CoreBlock#getDefinitions() definition} or the
+   * {@link CoreBlock#getDeclarations() declaration} of a {@link CoreBlock}
+   *
+   * @param iteratedBuffer
+   *          the {@link IteratedBuffer} to print.
+   * @return the printed {@link CharSequence}
+   */
+  public abstract CharSequence printIteratedBuffer(IteratedBuffer iteratedBuffer);
 
   /**
    * Method called to print a {@link BufferIterator} within the {@link CoreBlock#getDeclarations() declaration}

--- a/plugins/org.preesm.codegen/src/org/preesm/codegen/printer/CodegenAbstractPrinter.java
+++ b/plugins/org.preesm.codegen/src/org/preesm/codegen/printer/CodegenAbstractPrinter.java
@@ -49,6 +49,7 @@ import org.preesm.codegen.model.Block;
 import org.preesm.codegen.model.Buffer;
 import org.preesm.codegen.model.BufferIterator;
 import org.preesm.codegen.model.CallBlock;
+import org.preesm.codegen.model.ClusterBlock;
 import org.preesm.codegen.model.CodeElt;
 import org.preesm.codegen.model.CodegenPackage;
 import org.preesm.codegen.model.Communication;
@@ -681,6 +682,39 @@ public abstract class CodegenAbstractPrinter extends CodegenSwitch<CharSequence>
   }
 
   @Override
+  public CharSequence caseClusterBlock(final ClusterBlock clusterBlock) {
+    StringConcatenation result = new StringConcatenation();
+    String indentation = "";
+    boolean hasNewLine;
+
+    final CharSequence clusterBlockheader = printClusterBlockHeader(clusterBlock);
+    result.append(clusterBlockheader, indentation);
+
+    if (clusterBlockheader.length() > 0) {
+      indentation = CodegenAbstractPrinter.getLastLineIndentation(result);
+      result = CodegenAbstractPrinter.trimLastEOL(result);
+      hasNewLine = CodegenAbstractPrinter.endWithEOL(result);
+    } else {
+      hasNewLine = false;
+    }
+
+    // Visit all codeElements
+    final EList<CodeElt> codeElts = clusterBlock.getCodeElts();
+    for (final CodeElt codeElt : codeElts) {
+      final CharSequence code = doSwitch(codeElt);
+      result.append(code, indentation);
+    }
+
+    if (hasNewLine) {
+      result.newLineIfNotEmpty();
+    }
+
+    result.append(printClusterBlockFooter(clusterBlock), "");
+
+    return result;
+  }
+
+  @Override
   public CharSequence caseNullBuffer(final NullBuffer nullBuffer) {
     if (this.state.equals(PrinterState.PRINTING_DEFINITIONS)) {
       return printNullBufferDefinition(nullBuffer);
@@ -1135,6 +1169,24 @@ public abstract class CodegenAbstractPrinter extends CodegenSwitch<CharSequence>
    * @return the printed {@link CharSequence}
    */
   public abstract CharSequence printFiniteLoopBlockHeader(FiniteLoopBlock block);
+
+  /**
+   * Method called after printing all {@link CodeElt} belonging to a {@link ClusterBlock}.
+   *
+   * @param block
+   *          the {@link ClusterBlock} whose {@link CodeElt} were printed before calling this method.
+   * @return the printed {@link CharSequence}
+   */
+  public abstract CharSequence printClusterBlockFooter(ClusterBlock block);
+
+  /**
+   * Method called before printing all {@link CodeElt} belonging to a {@link ClusterBlock}.
+   *
+   * @param block
+   *          the {@link ClusterBlock} whose {@link CodeElt} will be printed after calling this method.
+   * @return the printed {@link CharSequence}
+   */
+  public abstract CharSequence printClusterBlockHeader(ClusterBlock block);
 
   /**
    * Method called to print a {@link NullBuffer} outside the {@link CoreBlock#getDefinitions() definition} or the

--- a/plugins/org.preesm.codegen/src/org/preesm/codegen/printer/DefaultPrinter.java
+++ b/plugins/org.preesm.codegen/src/org/preesm/codegen/printer/DefaultPrinter.java
@@ -44,6 +44,7 @@ import org.preesm.codegen.model.Block;
 import org.preesm.codegen.model.Buffer;
 import org.preesm.codegen.model.BufferIterator;
 import org.preesm.codegen.model.CallBlock;
+import org.preesm.codegen.model.ClusterBlock;
 import org.preesm.codegen.model.Communication;
 import org.preesm.codegen.model.Constant;
 import org.preesm.codegen.model.ConstantString;
@@ -230,6 +231,14 @@ public class DefaultPrinter extends CodegenAbstractPrinter {
   }
 
   public CharSequence printFiniteLoopBlockHeader(FiniteLoopBlock block) {
+    return "";
+  }
+
+  public CharSequence printClusterBlockFooter(ClusterBlock block) {
+    return "";
+  }
+
+  public CharSequence printClusterBlockHeader(ClusterBlock block) {
     return "";
   }
 

--- a/plugins/org.preesm.codegen/src/org/preesm/codegen/printer/DefaultPrinter.java
+++ b/plugins/org.preesm.codegen/src/org/preesm/codegen/printer/DefaultPrinter.java
@@ -57,6 +57,7 @@ import org.preesm.codegen.model.FreeDataTransferBuffer;
 import org.preesm.codegen.model.FunctionCall;
 import org.preesm.codegen.model.GlobalBufferDeclaration;
 import org.preesm.codegen.model.IntVar;
+import org.preesm.codegen.model.IteratedBuffer;
 import org.preesm.codegen.model.LoopBlock;
 import org.preesm.codegen.model.NullBuffer;
 import org.preesm.codegen.model.OutputDataTransfer;
@@ -281,6 +282,10 @@ public class DefaultPrinter extends CodegenAbstractPrinter {
   }
 
   public CharSequence printBufferIteratorDefinition(BufferIterator bufferIterator) {
+    return "";
+  }
+
+  public CharSequence printIteratedBuffer(IteratedBuffer iteratedBuffer) {
     return "";
   }
 

--- a/plugins/org.preesm.codegen/src/org/preesm/codegen/printer/DefaultPrinter.java
+++ b/plugins/org.preesm.codegen/src/org/preesm/codegen/printer/DefaultPrinter.java
@@ -65,6 +65,7 @@ import org.preesm.codegen.model.OutputDataTransfer;
 import org.preesm.codegen.model.PapifyAction;
 import org.preesm.codegen.model.PapifyFunctionCall;
 import org.preesm.codegen.model.RegisterSetUpAction;
+import org.preesm.codegen.model.SectionBlock;
 import org.preesm.codegen.model.SharedMemoryCommunication;
 import org.preesm.codegen.model.SpecialCall;
 import org.preesm.codegen.model.SubBuffer;
@@ -239,6 +240,14 @@ public class DefaultPrinter extends CodegenAbstractPrinter {
   }
 
   public CharSequence printClusterBlockHeader(ClusterBlock block) {
+    return "";
+  }
+
+  public CharSequence printSectionBlockFooter(SectionBlock block) {
+    return "";
+  }
+
+  public CharSequence printSectionBlockHeader(SectionBlock block) {
     return "";
   }
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -25,6 +25,9 @@ PREESM Changelog
 * SPiDER codegen considers empty PAPIFY configs as papify=false;
 * Update round buffer memory script to handle multiple inputs;
 * Schedule: Add an interface to perform transform
+* Codegen:
+  * Add IteratedBuffer, ClusterBlock, SectionBlock for clustering codegen
+  * Add conditional "#pragma omp parallel for" on FiniteLoopBlock
 
 ### Bug fix
 * fix #186


### PR DESCRIPTION
This PR introduces new models for codegen:
- IteratedBuffer: it is a derivative of Buffer that refers to a Buffer and an IntVar. The size attribute define the number of elements skipped in one iteration. This way of representation allows recursive iterated buffer implementation, handy when working inside of nested for loops.
- ClusterBlock: block that contains code element of actors included in clusters. It contains a string that precise the schedule expression. That block can be parallelize, meaning that OpenMP pragma can be added at the top of it. It also contains buffer definition for it scope.
- SectionBlock: block that contains code element that we will be printed with, for each, a #pragma omp section. Same as the top of block with #pragma omp sections.

I've also added a pragma omp parallel on top of for loop. 