### PR TITLE
Add null checks for codeGenDir

### DIFF
--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/memory/script/MemoryScriptEngine.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/memory/script/MemoryScriptEngine.java
@@ -212,6 +212,9 @@ public class MemoryScriptEngine {
    *
    */
   public void generateCode(final Scenario scenario, final String log) {
+    if (scenario.getCodegenDirectory() == null) {
+      throw new PreesmRuntimeException("Codegen path has not been specified in scenario, cannot go further.");
+    }
     final String codegenPath = scenario.getCodegenDirectory() + "/";
     final IFile iFile;
     try {

--- a/plugins/org.preesm.codegen.xtend/src/org/preesm/codegen/xtend/spider/SpiderCodegenTask.java
+++ b/plugins/org.preesm.codegen.xtend/src/org/preesm/codegen/xtend/spider/SpiderCodegenTask.java
@@ -134,6 +134,10 @@ public class SpiderCodegenTask extends AbstractTaskImplementation {
     // Retrieve inputs
     final Design architecture = (Design) inputs.get(AbstractWorkflowNodeImplementation.KEY_ARCHITECTURE);
     final Scenario scenario = (Scenario) inputs.get(AbstractWorkflowNodeImplementation.KEY_SCENARIO);
+    if (scenario.getCodegenDirectory() == null) {
+      throw new PreesmRuntimeException("Codegen path has not been specified in scenario, cannot go further.");
+    }
+
     final PiGraph pg = (PiGraph) inputs.get(AbstractWorkflowNodeImplementation.KEY_PI_GRAPH);
     // Check if we are using papify instrumentation
     final String papifyParameter = parameters.get(SpiderCodegenTask.PARAM_PAPIFY);

--- a/plugins/org.preesm.codegen/src/org/preesm/codegen/xtend/task/CodegenTask.java
+++ b/plugins/org.preesm.codegen/src/org/preesm/codegen/xtend/task/CodegenTask.java
@@ -129,6 +129,10 @@ public class CodegenTask extends AbstractTaskImplementation {
 
     // Retrieve inputs
     final Scenario scenario = (Scenario) inputs.get("scenario");
+    if (scenario.getCodegenDirectory() == null) {
+      throw new PreesmRuntimeException("Codegen path has not been specified in scenario, cannot go further.");
+    }
+
     final Design archi = (Design) inputs.get("architecture");
     final DirectedAcyclicGraph algoDAG = (DirectedAcyclicGraph) inputs.get("DAG");
     @SuppressWarnings("unchecked")

--- a/plugins/org.preesm.codegen/src/org/preesm/codegen/xtend/task/CodegenTask2.java
+++ b/plugins/org.preesm.codegen/src/org/preesm/codegen/xtend/task/CodegenTask2.java
@@ -58,6 +58,7 @@ import org.preesm.commons.doc.annotations.Parameter;
 import org.preesm.commons.doc.annotations.Port;
 import org.preesm.commons.doc.annotations.PreesmTask;
 import org.preesm.commons.doc.annotations.Value;
+import org.preesm.commons.exceptions.PreesmRuntimeException;
 import org.preesm.model.pisdf.PiGraph;
 import org.preesm.model.scenario.Scenario;
 import org.preesm.model.slam.Design;
@@ -115,6 +116,10 @@ public class CodegenTask2 extends AbstractTaskImplementation {
 
     // Retrieve inputs
     final Scenario scenario = (Scenario) inputs.get("scenario");
+    if (scenario.getCodegenDirectory() == null) {
+      throw new PreesmRuntimeException("Codegen path has not been specified in scenario, cannot go further.");
+    }
+
     final Design archi = (Design) inputs.get("architecture");
     final PiGraph algo = (PiGraph) inputs.get("PiMM");
 

--- a/plugins/org.preesm.model.scenario/src/org/preesm/model/scenario/serialize/ScenarioWriter.java
+++ b/plugins/org.preesm.model.scenario/src/org/preesm/model/scenario/serialize/ScenarioWriter.java
@@ -460,8 +460,11 @@ public class ScenarioWriter {
 
     final Element codeGenDir = this.dom.createElement("codegenDirectory");
     files.appendChild(codeGenDir);
-    codeGenDir.setAttribute("url", this.scenario.getCodegenDirectory());
-
+    String codeGenDirStr = this.scenario.getCodegenDirectory();
+    if (codeGenDirStr == null) {
+      codeGenDirStr = "";
+    }
+    codeGenDir.setAttribute("url", codeGenDirStr);
   }
 
   /**

--- a/plugins/org.preesm.ui.scenario/src/org/preesm/ui/scenario/editor/codegen/CodegenPage.java
+++ b/plugins/org.preesm.ui.scenario/src/org/preesm/ui/scenario/editor/codegen/CodegenPage.java
@@ -116,10 +116,14 @@ public class CodegenPage extends ScenarioPage {
     final Set<String> algoExtensions = new LinkedHashSet<>();
     algoExtensions.add("graphml");
 
+    String codeGenDirStr = this.scenario.getCodegenDirectory();
+    if (codeGenDirStr == null) {
+      codeGenDirStr = "";
+    }
     // Algorithm file chooser section
     createDirectorySection(managedForm, Messages.getString("Codegen.codeDirectory"),
         Messages.getString("Codegen.codeDirectoryDescription"), Messages.getString("Codegen.codeDirectoryEdit"),
-        this.scenario.getCodegenDirectory(), Messages.getString("Codegen.codeDirectoryBrowseTitle"));
+        codeGenDirStr, Messages.getString("Codegen.codeDirectoryBrowseTitle"));
 
     managedForm.refresh();
     managedForm.reflow(true);
@@ -200,7 +204,6 @@ public class CodegenPage extends ScenarioPage {
       final String path = FilenameUtils.separatorsToUnix(text1.getText());
       CodegenPage.this.scenario.setCodegenDirectory(path);
       firePropertyChange(IEditorPart.PROP_DIRTY);
-
     });
 
     gd.widthHint = 400;
@@ -214,6 +217,10 @@ public class CodegenPage extends ScenarioPage {
   }
 
   private void colorRedIfFileAbsent(final Text text) {
+    if (scenario.getCodegenDirectory() == null) {
+      FieldUtils.colorRedOnCondition(text, true);
+      return;
+    }
     final String codegenDirPath = text.getText().replaceAll("//", "/");
     final String sanitizedPath;
     if (codegenDirPath.startsWith("/")) {

--- a/release_notes.md
+++ b/release_notes.md
@@ -48,6 +48,7 @@ PREESM Changelog
 * Codegen:
   * Add IteratedBuffer, ClusterBlock, SectionBlock for clustering codegen
   * Add conditional "#pragma omp parallel for" on FiniteLoopBlock
+  * Add null checks for codeGenDir (since not set when the parser sees a null length);
 
 ### Bug fix
 * fix #186


### PR DESCRIPTION
Several tasks were not checking if the codegen path specified un scenario is not null. This branch adds such null checks.

Null codeGenDir may happen since the scenario parser sets this path only if it sees a String of a size greater than 0 in the xml file. Otherwise the path is not set, hence null.

Another fix would be to set a default value in the scenario xcore. I do not know what solution is best.