### PR TITLE
Cluster component constraints

### DIFF
--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/APGANClusteringAlgorithm.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/APGANClusteringAlgorithm.java
@@ -69,6 +69,8 @@ public class APGANClusteringAlgorithm implements IClusteringAlgorithm {
     // Get mergeable couple
     couples = PiSDFMergeabilty.getConnectedCouple(clusteringBuilder.getAlgorithm(),
         clusteringBuilder.getRepetitionVector());
+    // Remove couples of actors that are not in the same constraints
+    ClusteringHelper.removeConstrainedCouples(couples, clusteringBuilder.getScenario());
     return couples.isEmpty();
   }
 

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/Clustering.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/Clustering.java
@@ -90,7 +90,7 @@ public class Clustering extends AbstractTaskImplementation {
     String seed = parameters.get("Seed");
 
     // Instantiate a ClusteringBuilder and process clustering
-    ClusteringBuilder clusteringBuilder = new ClusteringBuilder(graph, algorithm, Long.parseLong(seed));
+    ClusteringBuilder clusteringBuilder = new ClusteringBuilder(graph, scenario, algorithm, Long.parseLong(seed));
     Map<AbstractActor, Schedule> scheduleMapping = clusteringBuilder.processClustering();
 
     // Print information in console

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/ClusteringBuilder.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/ClusteringBuilder.java
@@ -69,6 +69,8 @@ import org.preesm.model.pisdf.brv.BRVMethod;
 import org.preesm.model.pisdf.brv.PiBRV;
 import org.preesm.model.pisdf.check.PiGraphConsistenceChecker;
 import org.preesm.model.pisdf.factory.PiMMUserFactory;
+import org.preesm.model.scenario.Scenario;
+import org.preesm.model.slam.ComponentInstance;
 
 /**
  * @author dgageot
@@ -79,6 +81,8 @@ public class ClusteringBuilder {
   private Map<AbstractActor, Schedule> scheduleMapping;
 
   private PiGraph pigraph;
+
+  private Scenario scenario;
 
   private long seed;
 
@@ -96,9 +100,10 @@ public class ClusteringBuilder {
    * @param seed
    *          seed for random clustering algorithm
    */
-  public ClusteringBuilder(final PiGraph graph, final String algorithm, final long seed) {
+  public ClusteringBuilder(final PiGraph graph, final Scenario scenario, final String algorithm, final long seed) {
     this.scheduleMapping = new LinkedHashMap<>();
     this.pigraph = graph;
+    this.scenario = scenario;
     this.seed = seed;
     this.clusteringAlgorithm = clusteringAlgorithmFactory(algorithm);
     this.repetitionVector = null;
@@ -114,6 +119,10 @@ public class ClusteringBuilder {
 
   public Map<AbstractVertex, Long> getRepetitionVector() {
     return repetitionVector;
+  }
+
+  public Scenario getScenario() {
+    return scenario;
   }
 
   /**
@@ -362,8 +371,13 @@ public class ClusteringBuilder {
   private final PiGraph buildCluster(List<AbstractActor> actorList) {
     // Create the cluster actor and set it name
     PiGraph cluster = PiMMUserFactory.instance.createPiGraph();
+    cluster.setCluster(true);
     cluster.setName("cluster_" + nbCluster++);
     cluster.setUrl(pigraph.getUrl() + "/" + cluster.getName() + ".pi");
+
+    for (ComponentInstance component : ClusteringHelper.getListOfCommonComponent(actorList, scenario)) {
+      scenario.getConstraints().addConstraint(component, cluster);
+    }
 
     // Add cluster to the parent graph
     pigraph.addActor(cluster);

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/ClusteringBuilder.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/ClusteringBuilder.java
@@ -234,7 +234,7 @@ public class ClusteringBuilder {
 
   /**
    * clusterize actors together
-   * 
+   *
    * @param actors
    *          list of actors to clusterize
    * @return schedule tree of cluster
@@ -255,7 +255,7 @@ public class ClusteringBuilder {
 
   /**
    * clusterize actors regarding to the specified schedule
-   * 
+   *
    * @param schedule
    *          schedule to clusterize from
    * @return schedule tree of cluster
@@ -371,7 +371,7 @@ public class ClusteringBuilder {
   private final PiGraph buildCluster(List<AbstractActor> actorList) {
     // Create the cluster actor and set it name
     PiGraph cluster = PiMMUserFactory.instance.createPiGraph();
-    cluster.setCluster(true);
+    cluster.setClusterValue(true);
     cluster.setName("cluster_" + nbCluster++);
     cluster.setUrl(pigraph.getUrl() + "/" + cluster.getName() + ".pi");
 

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/ClusteringHelper.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/ClusteringHelper.java
@@ -36,9 +36,11 @@
 package org.preesm.algorithm.clustering;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.emf.common.util.ECollections;
 import org.eclipse.emf.common.util.EList;
 import org.preesm.algorithm.schedule.model.HierarchicalSchedule;
@@ -64,6 +66,7 @@ import org.preesm.model.pisdf.brv.BRVMethod;
 import org.preesm.model.pisdf.brv.PiBRV;
 import org.preesm.model.scenario.Scenario;
 import org.preesm.model.slam.Component;
+import org.preesm.model.slam.ComponentInstance;
 
 /**
  *
@@ -302,6 +305,42 @@ public class ClusteringHelper {
     } else {
       return (Parameter) setter;
     }
+  }
+
+  /**
+   * @param couples
+   *          list of mergeable couple
+   * @param scenario
+   *          scenario
+   */
+  public static void removeConstrainedCouples(List<Pair<AbstractActor, AbstractActor>> couples, Scenario scenario) {
+    List<Pair<AbstractActor, AbstractActor>> tmpCouples = new LinkedList<>();
+    tmpCouples.addAll(couples);
+    couples.clear();
+    for (Pair<AbstractActor, AbstractActor> couple : tmpCouples) {
+      List<ComponentInstance> componentList = getListOfCommonComponent(
+          Arrays.asList(couple.getLeft(), couple.getRight()), scenario);
+      if (!componentList.isEmpty()) {
+        couples.add(couple);
+      }
+    }
+  }
+
+  /**
+   * @param actorList
+   *          list of actor
+   * @param scenario
+   *          scenario
+   * @return
+   */
+  public static List<ComponentInstance> getListOfCommonComponent(List<AbstractActor> actorList, Scenario scenario) {
+    List<ComponentInstance> globalList = new LinkedList<>();
+    globalList.addAll(scenario.getPossibleMappings(actorList.get(0)));
+    for (AbstractActor actor : actorList) {
+      List<ComponentInstance> componentList = scenario.getPossibleMappings(actor);
+      globalList.retainAll(componentList);
+    }
+    return globalList;
   }
 
 }

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/DummyClusteringAlgorithm.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/DummyClusteringAlgorithm.java
@@ -65,6 +65,8 @@ public class DummyClusteringAlgorithm implements IClusteringAlgorithm {
     // Get mergeable couple
     couples = PiSDFMergeabilty.getConnectedCouple(clusteringBuilder.getAlgorithm(),
         clusteringBuilder.getRepetitionVector());
+    // Remove couples of actors that are not in the same constraints
+    ClusteringHelper.removeConstrainedCouples(couples, clusteringBuilder.getScenario());
     return couples.isEmpty();
   }
 

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/ParallelClusteringAlgorithm.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/ParallelClusteringAlgorithm.java
@@ -167,6 +167,8 @@ public class ParallelClusteringAlgorithm implements IClusteringAlgorithm {
     // Get mergeable couple
     couples = PiSDFMergeabilty.getConnectedCouple(clusteringBuilder.getAlgorithm(),
         clusteringBuilder.getRepetitionVector());
+    // Remove couples of actors that are not in the same constraints
+    ClusteringHelper.removeConstrainedCouples(couples, clusteringBuilder.getScenario());
     return couples.isEmpty();
   }
 

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/RandomClusteringAlgorithm.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/RandomClusteringAlgorithm.java
@@ -74,6 +74,8 @@ public class RandomClusteringAlgorithm implements IClusteringAlgorithm {
     // Get mergeable couple
     couples = PiSDFMergeabilty.getConnectedCouple(clusteringBuilder.getAlgorithm(),
         clusteringBuilder.getRepetitionVector());
+    // Remove couples of actors that are not in the same constraints
+    ClusteringHelper.removeConstrainedCouples(couples, clusteringBuilder.getScenario());
     return couples.isEmpty();
   }
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,6 +8,7 @@ PREESM Changelog
 
 ### Changes
 - PiSDF: PiGraph can be declared as a cluster. Hierarchy of cluster may be ignore by SR and DAG transformation.
+- Clustering: cluster are now mappable into component by retrieving common possible mapping of included actors
 
 ### Bug fix
 


### PR DESCRIPTION
Add methods to ClusteringHelper to get common component-constraints from a list of actor. It helps us to set possible mapping for a cluster and to not cluster couples that can't be mapped together.