### PR TITLE
Fix schedule data parallelism and short print

### DIFF
--- a/plugins/org.preesm.algorithm/model/Schedule.xcore
+++ b/plugins/org.preesm.algorithm/model/Schedule.xcore
@@ -46,7 +46,7 @@
 package org.preesm.algorithm.schedule.model
 
 import org.preesm.model.pisdf.AbstractActor
-import org.eclipse.emf.common.util.ECollections
+import org.preesm.algorithm.synthesis.schedule.SchedulePrinterSwitch
 
 // !!! This is needed as of the current versions of xcore/xtext
 // For some reason when using the default String/... (i.e. without the following)
@@ -105,16 +105,11 @@ interface Schedule {
 	 */
 	op boolean isParallel()
 	/*
-	 * Returns whether there is data parallelism (i.e. the same processing is done on different chunks
-	 * of data).
-	 */
-	op boolean isDataParallel() {
-		return isParallel && children.size == 1
-	}
-	/*
 	 * returns a String representing the schedule informally.
 	 */
-	op String shortPrint(boolean parallel)
+	op String shortPrint() {
+		return SchedulePrinterSwitch.print(this)
+	}
 	/*
 	 * Return true if the schedule is linked with an actor. This is the case when applying clustering, where
 	 * the attached actor of a HierarchicalSchedule is the clustered subraph.
@@ -182,27 +177,6 @@ interface ActorSchedule extends Schedule {
 	op AbstractActor[] getActors() {
 		return actorList.unmodifiableEList
 	}
-	op String shortPrint(boolean parallel) {
-		val StringBuilder toPrint = new StringBuilder()
-		// Print sequential operator
-		if (getRepetition() > 1) {
-			toPrint.append(getRepetition())
-			if (isParallel) {
-				toPrint.append("/")
-			}
-			toPrint.append("(")
-		}
-
-		toPrint.append(actors.map[it.getName()].join(""))
-
-		if (getRepetition() > 1) {
-			toPrint.append(")")
-		}
-		return toPrint.toString()
-	}
-	op Schedule[] getChildren() {
-		return ECollections.emptyEList
-	}
 }
 
 /*
@@ -228,22 +202,6 @@ class ParallelActorSchedule extends ActorSchedule, ParallelSchedule {
  * sequential, in the order of apparition in the list.
  */
 class SequentialHiearchicalSchedule extends HierarchicalSchedule, SequentialSchedule {
-	op String shortPrint(boolean parallel) {
-		val StringBuilder toPrint = new StringBuilder()
-		// Print sequential operator
-		if (getRepetition() > 1) {
-			if (parallel) {
-				toPrint.append(getRepetition() + "/(")
-			} else {
-				toPrint.append(getRepetition() + "(")
-			}
-		}
-		toPrint.append(children.map[it.shortPrint(false)].join("*"))
-		if (getRepetition() > 1) {
-			toPrint.append(")")
-		}
-		return toPrint.toString()
-	}
 }
 
 /*
@@ -251,16 +209,6 @@ class SequentialHiearchicalSchedule extends HierarchicalSchedule, SequentialSche
  * simultaneous (i.e. parallel).
  */
 class ParallelHiearchicalSchedule extends HierarchicalSchedule, ParallelSchedule {
-	op String shortPrint(boolean parallel) {
-		val StringBuilder toPrint = new StringBuilder()
-		// Print sequential operator
-		if (getRepetition() > 1) {
-			toPrint.append(getRepetition() + "/")
-		}
-		val String join = children.map[it.shortPrint(true)].join("|");
-		toPrint.append("(" + join + ")")
-		return toPrint.toString()
-	}
 }
 
 /*

--- a/plugins/org.preesm.algorithm/model/Schedule.xcore
+++ b/plugins/org.preesm.algorithm/model/Schedule.xcore
@@ -114,7 +114,7 @@ interface Schedule {
 	/*
 	 * returns a String representing the schedule informally.
 	 */
-	op String shortPrint()
+	op String shortPrint(boolean parallel)
 	/*
 	 * Return true if the schedule is linked with an actor. This is the case when applying clustering, where
 	 * the attached actor of a HierarchicalSchedule is the clustered subraph.
@@ -182,7 +182,7 @@ interface ActorSchedule extends Schedule {
 	op AbstractActor[] getActors() {
 		return actorList.unmodifiableEList
 	}
-	op String shortPrint() {
+	op String shortPrint(boolean parallel) {
 		val StringBuilder toPrint = new StringBuilder()
 		// Print sequential operator
 		if (getRepetition() > 1) {
@@ -228,13 +228,17 @@ class ParallelActorSchedule extends ActorSchedule, ParallelSchedule {
  * sequential, in the order of apparition in the list.
  */
 class SequentialHiearchicalSchedule extends HierarchicalSchedule, SequentialSchedule {
-	op String shortPrint() {
+	op String shortPrint(boolean parallel) {
 		val StringBuilder toPrint = new StringBuilder()
 		// Print sequential operator
 		if (getRepetition() > 1) {
-			toPrint.append(getRepetition() + "(")
+			if (parallel) {
+				toPrint.append(getRepetition() + "/(")
+			} else {
+				toPrint.append(getRepetition() + "(")
+			}
 		}
-		toPrint.append(children.map[it.shortPrint()].join("*"))
+		toPrint.append(children.map[it.shortPrint(false)].join("*"))
 		if (getRepetition() > 1) {
 			toPrint.append(")")
 		}
@@ -247,13 +251,13 @@ class SequentialHiearchicalSchedule extends HierarchicalSchedule, SequentialSche
  * simultaneous (i.e. parallel).
  */
 class ParallelHiearchicalSchedule extends HierarchicalSchedule, ParallelSchedule {
-	op String shortPrint() {
+	op String shortPrint(boolean parallel) {
 		val StringBuilder toPrint = new StringBuilder()
 		// Print sequential operator
 		if (getRepetition() > 1) {
 			toPrint.append(getRepetition() + "/")
 		}
-		val String join = children.map[it.shortPrint()].join("|");
+		val String join = children.map[it.shortPrint(true)].join("|");
 		toPrint.append("(" + join + ")")
 		return toPrint.toString()
 	}

--- a/plugins/org.preesm.algorithm/model/Schedule.xcore
+++ b/plugins/org.preesm.algorithm/model/Schedule.xcore
@@ -109,7 +109,7 @@ interface Schedule {
 	 * of data).
 	 */
 	op boolean isDataParallel() {
-		return isParallel && repetition > 1
+		return isParallel && children.size == 1
 	}
 	/*
 	 * returns a String representing the schedule informally.

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/Clustering.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/Clustering.java
@@ -99,7 +99,7 @@ public class Clustering extends AbstractTaskImplementation {
       // Printing
       String str = "Schedule for cluster " + entry.getKey().getName() + ":";
       PreesmLogger.getLogger().log(Level.INFO, str);
-      str = schedule.shortPrint();
+      str = schedule.shortPrint(false);
       PreesmLogger.getLogger().log(Level.INFO, str);
       str = "Estimated memory space needed: " + ClusteringHelper.getMemorySpaceNeededFor(schedule) + " bytes";
       PreesmLogger.getLogger().log(Level.INFO, str);

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/Clustering.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/Clustering.java
@@ -99,7 +99,7 @@ public class Clustering extends AbstractTaskImplementation {
       // Printing
       String str = "Schedule for cluster " + entry.getKey().getName() + ":";
       PreesmLogger.getLogger().log(Level.INFO, str);
-      str = schedule.shortPrint(false);
+      str = schedule.shortPrint();
       PreesmLogger.getLogger().log(Level.INFO, str);
       str = "Estimated memory space needed: " + ClusteringHelper.getMemorySpaceNeededFor(schedule) + " bytes";
       PreesmLogger.getLogger().log(Level.INFO, str);

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/SchedulePrinterSwitch.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/SchedulePrinterSwitch.java
@@ -55,18 +55,19 @@ public class SchedulePrinterSwitch extends ScheduleSwitch<String> {
     StringBuilder toPrint = new StringBuilder();
 
     if (object.getRepetition() > 1) {
+      toPrint.append(object.getRepetition());
       if (this.parentNode != null) {
         if (this.parentNode.isParallel()) {
-          toPrint.append(object.getRepetition() + "/(");
+          toPrint.append("/");
         }
-      } else {
-        toPrint.append(object.getRepetition() + "(");
       }
+      toPrint.append("(");
     }
 
     // Print sequential operator
     List<String> schedulesExpressions = new LinkedList<>();
     for (Schedule children : object.getChildren()) {
+      this.parentNode = object;
       schedulesExpressions.add(doSwitch(children));
     }
     toPrint.append(String.join("*", schedulesExpressions));

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/SchedulePrinterSwitch.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/SchedulePrinterSwitch.java
@@ -1,0 +1,105 @@
+package org.preesm.algorithm.synthesis.schedule;
+
+import java.util.LinkedList;
+import java.util.List;
+import org.preesm.algorithm.schedule.model.ActorSchedule;
+import org.preesm.algorithm.schedule.model.ParallelHiearchicalSchedule;
+import org.preesm.algorithm.schedule.model.Schedule;
+import org.preesm.algorithm.schedule.model.SequentialHiearchicalSchedule;
+import org.preesm.algorithm.schedule.model.util.ScheduleSwitch;
+import org.preesm.model.pisdf.AbstractActor;
+
+/**
+ * @author dgageot
+ *
+ */
+public class SchedulePrinterSwitch extends ScheduleSwitch<String> {
+
+  public static final String print(final Schedule s) {
+    return new SchedulePrinterSwitch().doSwitch(s);
+  }
+
+  Schedule parentNode;
+
+  public SchedulePrinterSwitch() {
+    super();
+    this.parentNode = null;
+  }
+
+  @Override
+  public String caseActorSchedule(ActorSchedule object) {
+    StringBuilder toPrint = new StringBuilder();
+    if (object.getRepetition() > 1) {
+      toPrint.append(object.getRepetition());
+      if (object.isParallel()) {
+        toPrint.append("/");
+      }
+      toPrint.append("(");
+    }
+
+    // Print actors names
+    List<String> actorsNames = new LinkedList<>();
+    for (AbstractActor actor : object.getActors()) {
+      actorsNames.add(actor.getName());
+    }
+    toPrint.append(String.join("", actorsNames));
+
+    if (object.getRepetition() > 1) {
+      toPrint.append(")");
+    }
+    return toPrint.toString();
+  }
+
+  @Override
+  public String caseSequentialHiearchicalSchedule(SequentialHiearchicalSchedule object) {
+    StringBuilder toPrint = new StringBuilder();
+
+    if (object.getRepetition() > 1) {
+      if (this.parentNode != null) {
+        if (this.parentNode.isParallel()) {
+          toPrint.append(object.getRepetition() + "/(");
+        }
+      } else {
+        toPrint.append(object.getRepetition() + "(");
+      }
+    }
+
+    // Print sequential operator
+    List<String> schedulesExpressions = new LinkedList<>();
+    for (Schedule children : object.getChildren()) {
+      schedulesExpressions.add(doSwitch(children));
+    }
+    toPrint.append(String.join("*", schedulesExpressions));
+
+    if (object.getRepetition() > 1) {
+      toPrint.append(")");
+    }
+
+    return toPrint.toString();
+  }
+
+  @Override
+  public String caseParallelHiearchicalSchedule(ParallelHiearchicalSchedule object) {
+    StringBuilder toPrint = new StringBuilder();
+
+    if (object.getRepetition() > 1) {
+      toPrint.append(object.getRepetition() + "/(");
+    }
+
+    // Print parallel operator
+    List<String> schedulesExpressions = new LinkedList<>();
+    for (Schedule children : object.getChildren()) {
+      this.parentNode = object;
+      schedulesExpressions.add(doSwitch(children));
+    }
+
+    toPrint.append(String.join("|", schedulesExpressions));
+
+    if (object.getRepetition() > 1) {
+      toPrint.append(")");
+    }
+
+    return toPrint.toString();
+  }
+
+}

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/transform/ScheduleDataParallelismExhibiter.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/transform/ScheduleDataParallelismExhibiter.java
@@ -61,8 +61,7 @@ public class ScheduleDataParallelismExhibiter implements IScheduleTransform {
       boolean sequentialPersistenceInside = !graph.getFifosWithDelay().isEmpty();
       if ((schedule.getRepetition() > 1) && !sequentialPersistenceInside) {
         ParallelHiearchicalSchedule parallelSchedule = ScheduleFactory.eINSTANCE.createParallelHiearchicalSchedule();
-        parallelSchedule.setRepetition(schedule.getRepetition());
-        schedule.setRepetition(1);
+        parallelSchedule.setRepetition(1);
         parallelSchedule.getChildren().add(schedule);
         return parallelSchedule;
       }

--- a/release_notes.md
+++ b/release_notes.md
@@ -7,11 +7,11 @@ PREESM Changelog
 ### New Feature
 
 ### Changes
-- PiSDF: PiGraph can be declared as a cluster. Hierarchy of cluster may be ignore by SR and DAG transformation.
-- Clustering: 
-  - cluster are now mappable into component by retrieving common possible mapping of included actors
-  - make code clearer for ClusteringBuilder
-- Schedule: Readapt the way of exhibiting data parallelism and print expression
+* PiSDF: PiGraph can be declared as a cluster. Hierarchy of cluster may be ignore by SR and DAG transformation.
+* Clustering: 
+  * cluster are now mappable into component by retrieving common possible mapping of included actors
+  * make code clearer for ClusteringBuilder
+* Schedule: Readapt the way of exhibiting data parallelism and print expression
 
 ### Bug fix
 * Fix #218: add support for non connected actors in SRDAG transform;

--- a/release_notes.md
+++ b/release_notes.md
@@ -7,10 +7,11 @@ PREESM Changelog
 ### New Feature
 
 ### Changes
-* PiSDF: PiGraph can be declared as a cluster. Hierarchy of cluster may be ignore by SR and DAG transformation.
-* Clustering: 
-  * cluster are now mappable into component by retrieving common possible mapping of included actors
-  * make code clearer for ClusteringBuilder
+- PiSDF: PiGraph can be declared as a cluster. Hierarchy of cluster may be ignore by SR and DAG transformation.
+- Clustering: 
+  - cluster are now mappable into component by retrieving common possible mapping of included actors
+  - make code clearer for ClusteringBuilder
+- Schedule: Readapt the way of exhibiting data parallelism and print expression
 
 ### Bug fix
 * Fix #218: add support for non connected actors in SRDAG transform;


### PR DESCRIPTION
This branch modify the way of printing schedule expression and to exhibit data parallelism of a repeted sequential schedule.

Before, a repeated sequential sequence could be parallelize by putting a parent parallel hierarchical with the repetition number of it. It makes the model not coherent because the sequential schedule was set to a repetition of one.

Now, repetition stays on the sequential node, the condition to have isDataParallelism() true is to have a parallel schedule and that there is only one child to it.

shortPrint now take an argument to know if the parent node was parallel. It is necessary to determine if the repetition are parallel or not.