### PR TITLE
Remove objective tolerance

### DIFF
--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/mapper/energyawareness/EnergyAwarenessProvider.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/mapper/energyawareness/EnergyAwarenessProvider.java
@@ -196,7 +196,8 @@ public class EnergyAwarenessProvider {
         this.bestConfig.putAll(this.configToAdd);
         this.mappingBest.putAll(mapping);
       }
-    } else if (Math.abs(this.objective - fps) < Math.abs(this.objective - this.closestFPS)) {
+    } else if ((Math.abs(this.objective - fps) < Math.abs(this.objective - this.closestFPS))
+        && this.minEnergy == Double.MAX_VALUE) {
       this.closestFPS = fps;
       this.energyNoObjective = energyThisOne;
       this.bestConfig.putAll(this.configToAdd);

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/mapper/energyawareness/EnergyAwarenessProvider.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/mapper/energyawareness/EnergyAwarenessProvider.java
@@ -196,8 +196,7 @@ public class EnergyAwarenessProvider {
         this.bestConfig.putAll(this.configToAdd);
         this.mappingBest.putAll(mapping);
       }
-    } else if ((Math.abs(this.objective - fps) < Math.abs(this.objective - this.closestFPS))
-        && this.minEnergy == Double.MAX_VALUE) {
+    } else if (fps > this.closestFPS && this.minEnergy == Double.MAX_VALUE) {
       this.closestFPS = fps;
       this.energyNoObjective = energyThisOne;
       this.bestConfig.putAll(this.configToAdd);

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/mapper/energyawareness/EnergyAwarenessProvider.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/mapper/energyawareness/EnergyAwarenessProvider.java
@@ -79,10 +79,7 @@ public class EnergyAwarenessProvider {
   Map<String, Integer> bestConfig = new LinkedHashMap<>();
 
   /** Objective data **/
-  double objective    = Double.MAX_VALUE;
-  double tolerance    = Double.MAX_VALUE;
-  double maxObjective = Double.MAX_VALUE;
-  double minObjective = Double.MAX_VALUE;
+  double objective = Double.MAX_VALUE;
 
   /** Searching info **/
   Set<Map<String, Integer>> configsAlreadyUsed  = new LinkedHashSet<>();
@@ -112,9 +109,6 @@ public class EnergyAwarenessProvider {
 
     /** Update everything related to the objective **/
     this.objective = this.scenarioOriginal.getEnergyConfig().getPerformanceObjective().getObjectiveEPS();
-    this.tolerance = this.scenarioOriginal.getEnergyConfig().getPerformanceObjective().getToleranceEPS();
-    this.maxObjective = this.objective + (this.objective * this.tolerance / 100);
-    this.minObjective = this.objective - (this.objective * this.tolerance / 100);
 
     /** Create the mapping scenario **/
     this.scenarioMapping = ScenarioUserFactory.createScenario();
@@ -195,7 +189,7 @@ public class EnergyAwarenessProvider {
     /**
      * Check if it is the best one
      */
-    if (fps <= this.maxObjective && fps >= this.minObjective) {
+    if (fps >= this.objective) {
       if (this.minEnergy > energyThisOne) {
         this.minEnergy = energyThisOne;
         this.closestFPS = fps;

--- a/plugins/org.preesm.model.scenario/model/Scenario.xcore
+++ b/plugins/org.preesm.model.scenario/model/Scenario.xcore
@@ -660,7 +660,6 @@ class PapiCpuID {
  }
  class PerformanceObjective{
  	double objectiveEPS
- 	double toleranceEPS
  }
 class PEPower wraps java.util.Map$Entry {
 	String key 		// The component type and the "base" power

--- a/plugins/org.preesm.model.scenario/src/org/preesm/model/scenario/serialize/ScenarioParser.java
+++ b/plugins/org.preesm.model.scenario/src/org/preesm/model/scenario/serialize/ScenarioParser.java
@@ -946,12 +946,6 @@ public class ScenarioParser {
       final double objectiveEPSValue = Double.parseDouble(objectiveEPS);
       this.scenario.getEnergyConfig().getPerformanceObjective().setObjectiveEPS(objectiveEPSValue);
     }
-    node = performanceObjectiveElt.getAttributeNode("toleranceEPS");
-    if (node != null) {
-      String toleranceEPS = node.getNodeValue();
-      final double toleranceEPSValue = Double.parseDouble(toleranceEPS);
-      this.scenario.getEnergyConfig().getPerformanceObjective().setToleranceEPS(toleranceEPSValue);
-    }
   }
 
   /**

--- a/plugins/org.preesm.model.scenario/src/org/preesm/model/scenario/serialize/ScenarioWriter.java
+++ b/plugins/org.preesm.model.scenario/src/org/preesm/model/scenario/serialize/ScenarioWriter.java
@@ -628,7 +628,6 @@ public class ScenarioWriter {
     parent.appendChild(performanceObjectiveElt);
 
     performanceObjectiveElt.setAttribute("objectiveEPS", Double.toString(performanceObjective.getObjectiveEPS()));
-    performanceObjectiveElt.setAttribute("toleranceEPS", Double.toString(performanceObjective.getToleranceEPS()));
   }
 
   /**

--- a/plugins/org.preesm.ui.scenario/src/org/preesm/ui/scenario/editor/energy/EnergyPage.java
+++ b/plugins/org.preesm.ui.scenario/src/org/preesm/ui/scenario/editor/energy/EnergyPage.java
@@ -915,8 +915,6 @@ public class EnergyPage extends ScenarioPage {
           if (dirty) {
             if (objective.getKey().equals(Messages.getString("Energy.objectiveLabel"))) {
               EnergyPage.this.scenario.getEnergyConfig().getPerformanceObjective().setObjectiveEPS(parseDouble);
-            } else {
-              EnergyPage.this.scenario.getEnergyConfig().getPerformanceObjective().setToleranceEPS(parseDouble);
             }
             firePropertyChange(IEditorPart.PROP_DIRTY);
             newTableViewer.refresh();

--- a/plugins/org.preesm.ui.scenario/src/org/preesm/ui/scenario/editor/energy/ObjectiveContentProvider.java
+++ b/plugins/org.preesm.ui.scenario/src/org/preesm/ui/scenario/editor/energy/ObjectiveContentProvider.java
@@ -69,8 +69,6 @@ public class ObjectiveContentProvider implements IStructuredContentProvider {
       final Map<String, Double> map = new LinkedHashMap<>();
       map.put(Messages.getString("Energy.objectiveLabel"),
           inputScenario.getEnergyConfig().getPerformanceObjective().getObjectiveEPS());
-      map.put(Messages.getString("Energy.toleranceLabel"),
-          inputScenario.getEnergyConfig().getPerformanceObjective().getToleranceEPS());
       final Set<Entry<String, Double>> entrySet = map.entrySet();
       this.elementList = new ArrayList<>(entrySet);
 

--- a/plugins/org.preesm.ui.scenario/src/org/preesm/ui/scenario/editor/messages.properties
+++ b/plugins/org.preesm.ui.scenario/src/org/preesm/ui/scenario/editor/messages.properties
@@ -187,7 +187,6 @@ Energy.energyExportExcel=Export
 Energy.opDefColumn=Operator Definition
 Energy.powerPlatformColumn=Associated power [W]
 Energy.objectiveLabel=Objective - in executions per second: 
-Energy.toleranceLabel=Tolerance - in %: 
 Energy.commsHeader=Source \\ Destination 
 Energy.energyImportPapifyFolder=Import papify-output
 Energy.energyImportPapifyFolderTitle=Select a papify-output in order to import all papify-output energy information

--- a/release_notes.md
+++ b/release_notes.md
@@ -7,6 +7,7 @@ PREESM Changelog
 ### New Feature
 
 ### Changes
+* EnergyAwareness: performance objective now is considered a minimum. The tolerance has been removed;
 
 ### Bug fix
 

--- a/tests/org.preesm.tests.ui.rcptt/scenario/edit-1/scenario-edit-1-expectedworkspace.verification
+++ b/tests/org.preesm.tests.ui.rcptt/scenario/edit-1/scenario-edit-1-expectedworkspace.verification
@@ -5,7 +5,7 @@ Element-Type: verification
 Element-Version: 2.0
 Id: _o0bS4AOcEem9q69sJFZzEg
 Runtime-Version: 2.4.2.201905080442
-Save-Time: 8/21/19, 1:33 PM
+Save-Time: 9/9/19 1:22 PM
 Verification-Type: org.eclipse.rcptt.verifications.workspace
 
 ------=_contents/org.ietr.preesm.reinforcement_learning/Spider/include/actor.h-6d2b2336-bd9f-36af-aebd-84fb520c099f
@@ -41,10 +41,10 @@ Fp12iTX3AaXKg2ewT0CvSlbey9sifqAt3GmlWrWuTGGR5dLAjJfVj7tlV6Ag/VsD+KCX+Aky3fxerb+2
 q/l/aVNPTnG2r264lSgoQ/b5TB4DJnEH7wBSZl2deT+95sxDKBztpfmEs3JAUhW5CrUvj6fR0DdTqrhY
 SpSm60dD5ZTKzit5Y3GcDyHmgc597ncSId1QZS20jndMSVdEZnAng3xSf2E+GY+Jdhg94VMKPR9c95L0
 4o3iRUKZqXPaXDY9PJsB+lNwLM7ki0niREm9Bgywf2xsNyzoLIg5GXZnvBmLS5y0OjiL2JUTCIBrqQvw
-4hh2antY2HyryCb0AtUmaZfLW5h9XO7UQYm3Fo3ME3h8eaXrrd6B2XZ0v3wiM5dPWbCaSiTUMSR6LEv7
-B5Bc+FDpeys9cNZESeL/4SvXXoKXJ0JeMv6+6oh5W2ACyypebz+autczPbji9OL+A1BLBwjP7DlzHgIA
-AKQFAABQSwECFAAUAAgICAAAACEAz+w5cx4CAACkBQAACAAJAAAAAAAAAAAAAAAAAAAALmNvbnRlbnRV
-VAUAAQAAAABQSwUGAAAAAAEAAQA/AAAAXQIAAAAA
+4hh2antY2HyryCb0AtUmaZfLW5h9XO7UQYm3Fo3ME3h8eaXrrd6B2XZ0v3wiM0f90h0s7R9AstxDJeat
+9MBZEyU9/4evLHoJXspPxjH+viqfeVtgAssqXm8/OrjXIL2u4vS8/gNQSwcIjDZpNRYCAACRBQAAUEsB
+AhQAFAAICAgAAAAhAIw2aTUWAgAAkQUAAAgACQAAAAAAAAAAAAAAAAAAAC5jb250ZW50VVQFAAEAAAAA
+UEsFBgAAAAABAAEAPwAAAFUCAAAAAA==
 ------=_contents/org.ietr.preesm.sobel/Scenarios/01-display_1core.scenario-bb76f53a-bd90-33e2-9cb0-e4f8e649c0a3--
 ------=_contents/org.ietr.preesm.reinforcement_learning/Algo/prediction/weight_generator.pi-9c35d2a1-360b-3d3a-b10a-96b20b33bf27
 Content-Type: q7/binary

--- a/tests/org.preesm.tests.ui.rcptt/scenario/generate-2/scenario-generate-2-expectedworkspace.verification
+++ b/tests/org.preesm.tests.ui.rcptt/scenario/generate-2/scenario-generate-2-expectedworkspace.verification
@@ -5,7 +5,7 @@ Element-Type: verification
 Element-Version: 2.0
 Id: _TdLogAOcEem9q69sJFZzEg
 Runtime-Version: 2.4.2.201905080442
-Save-Time: 8/21/19, 1:34 PM
+Save-Time: 9/9/19 1:24 PM
 Verification-Type: org.eclipse.rcptt.verifications.workspace
 
 ------=_contents/org.ietr.preesm.reinforcement_learning/Spider/include/actor.h-6d2b2336-bd9f-36af-aebd-84fb520c099f
@@ -86,16 +86,16 @@ Content-Type: q7/binary
 Entry-Name: contents/org.ietr.preesm.sobel/Scenarios/01-simple_display_1CoreX86.scenario
 
 UEsDBBQACAgIAAAAIQAAAAAAAAAAAAAAAAAIAAkALmNvbnRlbnRVVAUAAQAAAAClVMlu2zAQvecrCN4j
-2pfAB1pB4bS9NUETG+3JYKSxzJYbSCqw+/UdarElxTUQVBeRM49vFj4Ovz9oRd7AB2nNks6zGSVgCltK
-Uy3p+uXL7YLe5zc8FGCElza/IfjxnVQQ2nWzF6qyXsa9JrVXS8qsrzIJ0WfOAwSdBfsKin1CFJvNb4PU
-TsG2lMEpccycpGzI5Yu9jFDE2sN1ugRk85X18GNxlwUl9IgIq4AKzIP0SGb98SrZCsEM0eBFhJL1RJwN
-SkVGE6IX0sRA4FCAWidGOorZI756W7uzp/Fal+itJ0ZoWNKU+WyYcgOKIvzuAO96xb6DKLc/15uPner+
-o+6wi6kOzX3VUWpUw78qbr3Eujb4YXFHCdpwOZ/hR5O4Ihw+UtD/ck7K5ayroNsiun4SXuihgjVWnO4j
-by6Fs9N+CtHfUCl52AsP5VaD7qGtfSBjzFFU8CCieJZ/IE+Zcza1nvElml6ObvisRvbucusCI1MS8DB2
-Y3yjFyh4cFBIoTZNwx47/U1jXAQRJ+L+gkg5u8aJ3kl7uUsbiOA3QtUQ2Mns5O64smYnUVw4hlpp9e70
-FKv37kEeGHhnvRamgMfXX/jG5RsQ268+Pz2jNtI8i1Zhiog6mU7CGAXBMcfOc+4vUEsHCPH48VfhAQAA
-GgUAAFBLAQIUABQACAgIAAAAIQDx+PFX4QEAABoFAAAIAAkAAAAAAAAAAAAAAAAAAAAuY29udGVudFVU
-BQABAAAAAFBLBQYAAAAAAQABAD8AAAAgAgAAAAA=
+2pfAB1lB4SS9NUETG+3JYKSxzJYbhlRg9+s72mJJcQ0E1UXkzOOb7ZHp7cFo9gYYlLNLPk9mnIHNXaFs
+ueTrl4frBb/NrtKQg5WoXHbF6Et3SkNo181e6tKhinvDKtRLLhyWiYKIiUeAYJLgXkGLL4QSs/l1UMZr
+2BYqeC2PiVdcDLkw36sIeawQLtPVQDFfOYQfi5skaGlGRFQFlGDvFBKZw+NFshWBBaEBZYRC9ESpGJRK
+jDZElMrGwOCQg17XjHwUs0d8RVf5k6fxOl/TO2RWGljyOvPZMOUGFGX43QE+9Ep8B1lsf643nzvV/Ufd
+EWdTHZr7qqMypIZ/Vdx6mfNt8MPihjOy0XI+o4/X4opw+ExB/8s5KTcVXQXdltDVk0Rphgo2VHE9j6wZ
+Sire91OI+UZKycJeIhRbA6aHtvaBjClHWcKdjPJZ/YGszjwVU+sJX5Dp5eiH12pk74Zb5RSZs0CHqRvj
+iZ6hSIOHXEm9aRr22OlvGuMsiHkZ92dEmopLnOSdtDf19QYi4EbqCoJ4N3u1O66c3SkSFz1DrbR6d30V
+y4/uQR4UeOfQSJvD4+svuuPqDZjrV/dPz6SNZHZSwYiR3jRxetT+AlBLBwg9ircD2QEAAAcFAABQSwEC
+FAAUAAgICAAAACEAPYq3A9kBAAAHBQAACAAJAAAAAAAAAAAAAAAAAAAALmNvbnRlbnRVVAUAAQAAAABQ
+SwUGAAAAAAEAAQA/AAAAGAIAAAAA
 ------=_contents/org.ietr.preesm.sobel/Scenarios/01-simple_display_1CoreX86.scenario-cd07d348-8dce-3d17-95dc-47c6342f0e67--
 ------=_contents/org.ietr.preesm.sobel/Workflows/Codegen.workflow-79c4da17-9b60-31ce-b717-3c96e188d0aa
 Content-Type: q7/binary


### PR DESCRIPTION
In energy awareness, the performance objective now is considered a minimum. Hence, the tolerance in the objective now is not used.

Both RCPTT tests and release notes have been updated accordingly.