### PR TITLE
Fixup clusters

### DIFF
--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/statictools/PiMMHelper.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/statictools/PiMMHelper.java
@@ -343,7 +343,9 @@ public class PiMMHelper {
     }
     // 2. We deal with hierarchical stuff
     for (final PiGraph g : piGraph.getChildrenGraphs()) {
-      recursiveRemovePersistence(g);
+      if (!g.isCluster()) {
+        recursiveRemovePersistence(g);
+      }
     }
   }
 

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/statictools/PiSDFParameterResolverVisitor.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/statictools/PiSDFParameterResolverVisitor.java
@@ -229,6 +229,10 @@ public class PiSDFParameterResolverVisitor extends PiMMSwitch<Boolean> {
           + " has configuration actors. It is thus impossible to use the" + " Static PiMM to SRDAG transformation.");
     }
 
+    if (graph.isCluster()) {
+      return caseOtherActors(graph);
+    }
+
     // Resolve input interfaces
     for (final ConfigInputInterface p : graph.getConfigInputInterfaces()) {
       doSwitch(p);

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiSDFMergeabilty.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiSDFMergeabilty.java
@@ -91,7 +91,6 @@ public class PiSDFMergeabilty {
     final long clusterRepetition = MathFunctionsHelper.gcd(CollectionUtil.mapGetAll(brv, Arrays.asList(x, y)));
 
     boolean result = true;
-    boolean delayInside = false;
 
     for (final Fifo incomingFifo : incomingFifos) {
       final long prodRate = incomingFifo.getSourcePort().getPortRateExpression().evaluate();
@@ -104,14 +103,13 @@ public class PiSDFMergeabilty {
         delayValue = 0;
       } else {
         delayValue = delay.getExpression().evaluate();
-        delayInside = true;
       }
 
       // Precedence shift condition verification
-      final boolean fifoTransferNotNull = (consRate / (individualRepetition * prodRate)) > 0;
-      final boolean fifoValueIsConsistent = (consRate % (individualRepetition * prodRate)) == 0;
-      final boolean delayIsPresent = (delayValue / (individualRepetition * prodRate)) >= 0;
-      final boolean delayValueIsConsistent = (delayValue % (individualRepetition * prodRate)) == 0;
+      final boolean fifoTransferNotNull = (prodRate / (individualRepetition * consRate)) > 0;
+      final boolean fifoValueIsConsistent = (prodRate % (individualRepetition * consRate)) == 0;
+      final boolean delayIsPresent = (delayValue / (individualRepetition * consRate)) >= 0;
+      final boolean delayValueIsConsistent = (delayValue % (individualRepetition * consRate)) == 0;
 
       if (!(fifoValueIsConsistent && delayValueIsConsistent && fifoTransferNotNull && delayIsPresent)) {
         result = false;
@@ -128,7 +126,6 @@ public class PiSDFMergeabilty {
         delayValue = 0;
       } else {
         delayValue = delay.getExpression().evaluate();
-        delayInside = true;
       }
 
       // Precedence shift condition verification
@@ -143,7 +140,7 @@ public class PiSDFMergeabilty {
     }
 
     // If no delay was present on all fifos, the result can be true without compromising clustering
-    return result || !delayInside;
+    return result;
   }
 
   private static List<Fifo> findInFifos(final AbstractActor x, final AbstractActor y) {
@@ -202,8 +199,8 @@ public class PiSDFMergeabilty {
       }
     }
 
-    final boolean yDividesX = brv.get(x) % brv.get(y) == 0;
-    final boolean xDividesY = brv.get(y) % brv.get(x) == 0;
+    final boolean yDividesX = (brv.get(x) % brv.get(y)) == 0;
+    final boolean xDividesY = (brv.get(y) % brv.get(x)) == 0;
     return !outgoingFifos.isEmpty() && (yDividesX || xDividesY);
   }
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -20,7 +20,7 @@ PREESM Changelog
 * Fix #83
 * Fix #128
 * Fix #190
-
+* Fix problem with precedence shift condition (clustering purposes)
 
 ## Release version 3.17.0
 *2019.09.09*


### PR DESCRIPTION
A mistake in isPrecedenceShiftConditionValid was leading to a wrong clustering result, this PR solves it.
Also, since we have added the "cluster" attributes in PiGraph, when resolving parameters and persistences, it is needed to not explore those specific subgraph. For that purposes, I've added few if condition to treat cluster as atomic actor.