### PR TITLE
Fix cluster seed parameter transfer to clustering algorithm

### DIFF
--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/ClusteringBuilder.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/ClusteringBuilder.java
@@ -126,10 +126,10 @@ public class ClusteringBuilder {
    */
   public ClusteringBuilder(final PiGraph graph, final Scenario scenario, final String algorithm, final long seed) {
     this.scheduleMapping = new LinkedHashMap<>();
+    this.seed = seed;
     this.clusteringAlgorithm = clusteringAlgorithmFactory(algorithm);
     this.pigraph = graph;
     this.scenario = scenario;
-    this.seed = seed;
     this.repetitionVector = null;
   }
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -35,6 +35,7 @@ PREESM Changelog
 * Fix #128
 * Fix #190
 * Fix problem with precedence shift condition (clustering purposes)
+* Fix random seed parameter transfer to clustering algorithm
 * Fix various bugs in the experimental external mapping importer.
 
 ## Release version 3.17.0


### PR DESCRIPTION
Seed was not taken in consideration in clustering algorithm instantiation because it was given at the wrong moment. This PR solves this issue.