### PR TITLE
(PiSDF) Fix PiSDFMergeability condition

### DIFF
--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiSDFMergeabilty.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiSDFMergeabilty.java
@@ -194,7 +194,7 @@ public class PiSDFMergeabilty {
 
     for (final DataOutputPort dop : x.getDataOutputPorts()) {
       // Add all outgoing fifo that are not contained in the future cluster
-      if (dop.getOutgoingFifo().getDelay() == null) {
+      if (dop.getOutgoingFifo().getDelay() == null && dop.getOutgoingFifo().getTarget() == y) {
         outgoingFifos.add(dop.getOutgoingFifo());
       }
     }
@@ -220,7 +220,7 @@ public class PiSDFMergeabilty {
     }
     // Verify theses fourth conditions
     final boolean precedenceShiftA = PiSDFMergeabilty.isPrecedenceShiftConditionValid(x, y, x, brv);
-    final boolean precedenceShiftB = PiSDFMergeabilty.isPrecedenceShiftConditionValid(y, x, x, brv);
+    final boolean precedenceShiftB = PiSDFMergeabilty.isPrecedenceShiftConditionValid(y, x, y, brv);
     final boolean cycleIntroduction = PiSDFMergeabilty.isCycleIntroductionConditionValid(x, y);
     final boolean hiddenDelay = PiSDFMergeabilty.isHiddenDelayConditionValid(x, y, brv);
     return cycleIntroduction && hiddenDelay && precedenceShiftA && precedenceShiftB;


### PR DESCRIPTION
Clustering rules were not coherent in [Pino composition theorem](https://ieeexplore.ieee.org/document/540525). There is a typing error in Precedence Shift B definition (second condition of composition theorem), it leads to clusters that may not be possible. In addition, Hidden Delay condition wasn't correctly implemented by myself. This PR solves these errors. 

