### PR TITLE
New schedule transform and new clustering parameter

### DIFF
--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/ClusteringBuilder.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/ClusteringBuilder.java
@@ -217,8 +217,6 @@ public class ClusteringBuilder {
       // Clusterize given actors
       HierarchicalSchedule clusterSchedule = (HierarchicalSchedule) clusterize(actorsFound);
       scheduleMapping.put(clusterSchedule.getAttachedActor(), clusterSchedule);
-      // Compute BRV with the corresponding graph
-      repetitionVector = PiBRV.compute(this.pigraph, BRVMethod.LCM);
     }
 
     // Perform flattening transformation on schedule graph
@@ -393,6 +391,9 @@ public class ClusteringBuilder {
     for (AbstractActor a : actorList) {
       addActorToHierarchicalSchedule(schedule, a, repetitionVector.get(a) / clusterRepetition);
     }
+
+    // Compute BRV with the corresponding graph
+    repetitionVector = PiBRV.compute(this.pigraph, BRVMethod.LCM);
 
     return schedule;
   }

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/ClusteringBuilder.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/ClusteringBuilder.java
@@ -118,7 +118,7 @@ public class ClusteringBuilder {
   private int nbCluster;
 
   /**
-   * Is clustering criteria is memory space or performance?
+   * Boolean that stored user's choice about performance optimization.
    */
   private boolean performanceOptimization;
 

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/SchedulePrinterSwitch.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/SchedulePrinterSwitch.java
@@ -67,7 +67,7 @@ public class SchedulePrinterSwitch extends ScheduleSwitch<String> {
     final StringBuilder toPrint = new StringBuilder();
     if (object.getRepetition() > 1) {
       toPrint.append(object.getRepetition());
-      if (object.isParallel()) {
+      if (object.getParent().isParallel()) {
         toPrint.append("/");
       }
       toPrint.append("(");

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/transform/ScheduleFlattener.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/transform/ScheduleFlattener.java
@@ -53,7 +53,7 @@ public class ScheduleFlattener implements IScheduleTransform {
   @Override
   public Schedule performTransform(final Schedule schedule) {
     // If it is an hierarchical schedule, explore and cluster actors
-    if (schedule instanceof HierarchicalSchedule) {
+    if (schedule instanceof HierarchicalSchedule && schedule.hasAttachedActor()) {
       final HierarchicalSchedule hierSchedule = (HierarchicalSchedule) schedule;
       // Retrieve childrens schedule and actors
       final List<Schedule> childSchedules = new LinkedList<>();

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/transform/ScheduleParallelismOptimizer.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/transform/ScheduleParallelismOptimizer.java
@@ -3,7 +3,7 @@ package org.preesm.algorithm.synthesis.schedule.transform;
 import java.util.LinkedList;
 import java.util.List;
 import org.preesm.algorithm.schedule.model.HierarchicalSchedule;
-import org.preesm.algorithm.schedule.model.ParallelActorSchedule;
+import org.preesm.algorithm.schedule.model.ParallelHiearchicalSchedule;
 import org.preesm.algorithm.schedule.model.Schedule;
 import org.preesm.algorithm.schedule.model.ScheduleFactory;
 import org.preesm.algorithm.schedule.model.SequentialHiearchicalSchedule;
@@ -44,7 +44,8 @@ public class ScheduleParallelismOptimizer implements IScheduleTransform {
           if (processedChild instanceof SequentialSchedule) {
             isComposedOfSequentialSchedule = true;
             // Is child a parallel actor schedule that can be parallelized out of it cluster?
-          } else if ((processedChild instanceof ParallelActorSchedule) && (processedChild.getRepetition() == 1)) {
+          } else if ((processedChild instanceof ParallelHiearchicalSchedule) && (processedChild.getRepetition() == 1)
+              && (processedChild.getChildren().size() == 1)) {
             // Register it as a parallel schedule in SCHEDULE list of children
             parallelSchedules.add(processedChild);
           }

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/transform/ScheduleParallelismOptimizer.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/transform/ScheduleParallelismOptimizer.java
@@ -100,8 +100,8 @@ public class ScheduleParallelismOptimizer implements IScheduleTransform {
 
       // Set repetition value for moved schedules
       final long repetitionSchedule = schedule.getRepetition();
-      leftSchedules.stream().forEach(x -> x.setRepetition(repetitionSchedule));
-      rightSchedules.stream().forEach(x -> x.setRepetition(repetitionSchedule));
+      leftSchedules.stream().forEach(x -> x.getChildren().get(0).setRepetition(repetitionSchedule));
+      rightSchedules.stream().forEach(x -> x.getChildren().get(0).setRepetition(repetitionSchedule));
 
       return temporaryHierarchy;
     }

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/transform/ScheduleParallelismOptimizer.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/transform/ScheduleParallelismOptimizer.java
@@ -11,6 +11,9 @@ import org.preesm.algorithm.schedule.model.SequentialSchedule;
 
 /**
  * @author dgageot
+ * 
+ *         Identifies and moves actors inside a sequential and repeated schedule that can be parallelized outside to
+ *         gain in performance. The input schedule should have been flattened for a better result.
  *
  */
 public class ScheduleParallelismOptimizer implements IScheduleTransform {

--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/transform/ScheduleParallelismOptimizer.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/synthesis/schedule/transform/ScheduleParallelismOptimizer.java
@@ -1,0 +1,108 @@
+package org.preesm.algorithm.synthesis.schedule.transform;
+
+import java.util.LinkedList;
+import java.util.List;
+import org.preesm.algorithm.schedule.model.HierarchicalSchedule;
+import org.preesm.algorithm.schedule.model.ParallelActorSchedule;
+import org.preesm.algorithm.schedule.model.Schedule;
+import org.preesm.algorithm.schedule.model.ScheduleFactory;
+import org.preesm.algorithm.schedule.model.SequentialHiearchicalSchedule;
+import org.preesm.algorithm.schedule.model.SequentialSchedule;
+
+/**
+ * @author dgageot
+ *
+ */
+public class ScheduleParallelismOptimizer implements IScheduleTransform {
+
+  private static final int TEMPORARY_HIERARCHY = -1;
+
+  @Override
+  public Schedule performTransform(final Schedule schedule) {
+    // If it is an hierarchical schedule, explore child
+    if (schedule instanceof HierarchicalSchedule) {
+
+      // This boolean variable is used to determine if the schedule being processed is composed of sequential element
+      boolean isComposedOfSequentialSchedule = false;
+      // Retrieve childrens schedule and actors
+      final HierarchicalSchedule hierSchedule = (HierarchicalSchedule) schedule;
+      final List<Schedule> childSchedules = new LinkedList<>();
+      childSchedules.addAll(hierSchedule.getChildren());
+      // Clear list of children schedule
+      hierSchedule.getChildren().clear();
+      final List<Schedule> parallelSchedules = new LinkedList<>();
+      for (final Schedule child : childSchedules) {
+        final Schedule processedChild = performTransform(child);
+        // Is processed children a temporary hierarchy that has been transformed by this algorithm?
+        if (processedChild.getRepetition() == ScheduleParallelismOptimizer.TEMPORARY_HIERARCHY) {
+          schedule.getChildren().addAll(processedChild.getChildren());
+        } else {
+          // Is child a sequential schedule?
+          if (processedChild instanceof SequentialSchedule) {
+            isComposedOfSequentialSchedule = true;
+            // Is child a parallel actor schedule that can be parallelized out of it cluster?
+          } else if ((processedChild instanceof ParallelActorSchedule) && (processedChild.getRepetition() == 1)) {
+            // Register it as a parallel schedule in SCHEDULE list of children
+            parallelSchedules.add(processedChild);
+          }
+          // Add processed children to SCHEDULE
+          schedule.getChildren().add(processedChild);
+        }
+      }
+
+      return generateTemporaryHierarchy(schedule, parallelSchedules, isComposedOfSequentialSchedule);
+
+    }
+
+    return schedule;
+  }
+
+  private Schedule generateTemporaryHierarchy(final Schedule schedule, final List<Schedule> parallelSchedules,
+      final boolean isComposedOfSequentialSchedule) {
+    // If parallelizable schedule are inside of a cluster that also regroup of sequential schedule,
+    // we may pull up parallelizable schedule to the parent hierarchical schedule
+    if ((schedule.getRepetition() > 1) && !parallelSchedules.isEmpty() && isComposedOfSequentialSchedule) {
+      // This schedule is temporary : we use to carry children that we be insert in the parent hierarchy
+      final SequentialHiearchicalSchedule temporaryHierarchy = ScheduleFactory.eINSTANCE
+          .createSequentialHiearchicalSchedule();
+      temporaryHierarchy.setRepetition(ScheduleParallelismOptimizer.TEMPORARY_HIERARCHY);
+
+      // Retrieve parallel schedule that can be pulled up
+      final List<Schedule> leftSchedules = new LinkedList<>();
+      final List<Schedule> rightSchedules = new LinkedList<>();
+      boolean insertRight = false;
+      for (final Schedule child : schedule.getChildren()) {
+        // If a child is not contained in parallel child schedule list, it may be a sequential schedule. If it is a
+        // sequential schedule, every parallel child that we will find next will be pulled up at the right of original
+        // schedule
+        if (parallelSchedules.contains(child)) {
+          if (insertRight) {
+            rightSchedules.add(child);
+          } else {
+            leftSchedules.add(child);
+          }
+        } else {
+          insertRight = true;
+          // If we've found an another sequential schedule in children, we may clear our list of right parallel
+          // element because of data dependency
+          rightSchedules.clear();
+        }
+      }
+
+      // Move identified parallel node to temporary hierarchy node
+      temporaryHierarchy.getChildren().addAll(leftSchedules);
+      temporaryHierarchy.getChildren().add(schedule);
+      temporaryHierarchy.getChildren().addAll(rightSchedules);
+
+      // Set repetition value for moved schedules
+      final long repetitionSchedule = schedule.getRepetition();
+      leftSchedules.stream().forEach(x -> x.setRepetition(repetitionSchedule));
+      rightSchedules.stream().forEach(x -> x.setRepetition(repetitionSchedule));
+
+      return temporaryHierarchy;
+    }
+
+    return schedule;
+  }
+
+}

--- a/release_notes.md
+++ b/release_notes.md
@@ -10,6 +10,10 @@ PREESM Changelog
 ### Changes
 * Fix compile error in generated TCP code (but execution hangs...);
 * Refactor;
+* Clustering:
+	* Workflow task PiSDF Clustering is now documented
+	* Implemented a new schedule transform that optimize parallelism inside of sequantial schedule hierarchy
+	* New parameter: Optimization criteria (memory or performance)
 
 ### Bug fix
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -48,7 +48,6 @@ PREESM Changelog
 * Simulation tab of scenario now has an option to import all data types from
   the graph, with predefined default values for common type names.
 
-
 ### Bug fix
 * Fix #74
 * Fix #80

--- a/tests/org.preesm.tests.integration/resources/org.ietr.preesm.loopgen-sobel-erosion-dilation/Workflows/CodegenDistribCluster.workflow
+++ b/tests/org.preesm.tests.integration/resources/org.ietr.preesm.loopgen-sobel-erosion-dilation/Workflows/CodegenDistribCluster.workflow
@@ -4,6 +4,7 @@
     <dftools:task pluginId="org.ietr.preesm.pisdfclustering" taskId="Clustering">
         <dftools:data key="variables">
             <dftools:variable name="Algorithm" value="APGAN"/>
+            <dftools:variable name="Optimization criteria" value="Performance"/>
             <dftools:variable name="Seed" value="3"/>
         </dftools:data>
     </dftools:task>


### PR DESCRIPTION
This PR involves a new schedule transform: Parallelism Optimizer. It goals is to explore a schedule and optimize parallelism inside of a sequential schedule hierarchy in which we can find both sequential and parallel element. The goal is to pull up parallel schedule to the parent node to allow them to be execute in parallel, otherwise they would be execute sequentially with the rest of the hierarchy.

**Example with a schedule expression from Stereo Matching app:**
`...*Cost_Parallel_Work_grayL*60(Cost_Parallel_Work_CostConstruction*Cost_Parallel_Work_AggregateCost*Cost_Parallel_Work_disparitySelect*Cost_Parallel_Work_Broadcast5)*Cost_Parallel_Work_rawDisparity*...`
ScheduleParallelismOptimizer will give us:
`...*Cost_Parallel_Work_grayL*60/(Cost_Parallel_Work_CostConstruction)*60/(Cost_Parallel_Work_AggregateCost)*60(Cost_Parallel_Work_disparitySelect*Cost_Parallel_Work_Broadcast5)*Cost_Parallel_Work_rawDisparity*...`

This new transform brings a new parameter to "PiSDF Clustering": Optimization criteria. You can chose between Memory and Performance. I took advantage of this modification to document the task.