### PR TITLE
New button in simulation tab: fetch all data size names from graph

### DIFF
--- a/plugins/org.preesm.model.scenario/build.properties
+++ b/plugins/org.preesm.model.scenario/build.properties
@@ -45,7 +45,8 @@ bin.includes = .,\
                model/,\
                META-INF/,\
                plugin.properties,\
-               plugin.xml
+               plugin.xml,\
+               resources/
 jars.compile.order = .
 source.. = src/,\
            model/,\

--- a/plugins/org.preesm.model.scenario/resources/default_type_sizes_ubuntu_18.04_x64_gcc_7.4.0.csv
+++ b/plugins/org.preesm.model.scenario/resources/default_type_sizes_ubuntu_18.04_x64_gcc_7.4.0.csv
@@ -1,0 +1,43 @@
+void:1
+char:1
+unsigned char:1
+short:2
+unsigned short:2
+int:4
+unsigned int:4
+long:8
+unsigned long:8
+long long:8
+unsigned long long:8
+float:4
+double:8
+long double:16
+long double:16
+int8_t:1
+int16_t:2
+int32_t:4
+int64_t:8
+int_fast8_t:1
+int_fast16_t:8
+int_fast32_t:8
+int_fast64_t:8
+int_least8_t:1
+int_least16_t:2
+int_least32_t:4
+int_least64_t:8
+intmax_t:8
+intptr_t:8
+uint8_t:1
+uint16_t:2
+uint32_t:4
+uint64_t:8
+uint_fast8_t:1
+uint_fast16_t:8
+uint_fast32_t:8
+uint_fast64_t:8
+uint_least8_t:1
+uint_least16_t:2
+uint_least32_t:4
+uint_least64_t:8
+uintmax_t:8
+uintptr_t:8

--- a/plugins/org.preesm.model.scenario/src/org/preesm/model/scenario/util/DefaultTypeSizes.java
+++ b/plugins/org.preesm.model.scenario/src/org/preesm/model/scenario/util/DefaultTypeSizes.java
@@ -3,6 +3,7 @@ package org.preesm.model.scenario.util;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.preesm.commons.exceptions.PreesmRuntimeException;
@@ -48,7 +49,7 @@ public final class DefaultTypeSizes {
         final String[] split = typeDef.split(":");
         res.put(split[0], Long.parseLong(split[1]));
       });
-      return Map.copyOf(res);
+      return Collections.unmodifiableMap(res);
     } catch (final IOException e) {
       throw new PreesmRuntimeException("Could not read CSV file storing default data type sizes.", e);
     }

--- a/plugins/org.preesm.model.scenario/src/org/preesm/model/scenario/util/DefaultTypeSizes.java
+++ b/plugins/org.preesm.model.scenario/src/org/preesm/model/scenario/util/DefaultTypeSizes.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.preesm.commons.exceptions.PreesmRuntimeException;
 import org.preesm.commons.files.PreesmResourcesHelper;
 import org.preesm.commons.files.URLHelper;
+import org.preesm.model.scenario.ScenarioConstants;
 
 /**
  *
@@ -61,7 +62,7 @@ public final class DefaultTypeSizes {
     if (this.defaultTypeSizesMap.containsKey(typeName)) {
       return this.defaultTypeSizesMap.get(typeName);
     } else {
-      return 1L;
+      return (long) ScenarioConstants.DEFAULT_DATA_TYPE_SIZE.getValue();
     }
   }
 

--- a/plugins/org.preesm.model.scenario/src/org/preesm/model/scenario/util/DefaultTypeSizes.java
+++ b/plugins/org.preesm.model.scenario/src/org/preesm/model/scenario/util/DefaultTypeSizes.java
@@ -22,23 +22,23 @@ public final class DefaultTypeSizes {
   private static final String CSV_FILE_UBUNTU_18_04_X64_GCC_7_4_0 = "default_type_sizes_ubuntu_18.04_x64_gcc_7.4.0.csv";
 
   public static final DefaultTypeSizes getInstance() {
-    return instance;
+    return DefaultTypeSizes.instance;
   }
 
-  private final Map<String, Long> defaultTypeSizes;
+  private final Map<String, Long> defaultTypeSizesMap;
 
   private DefaultTypeSizes() {
-    this.defaultTypeSizes = initDefaultTypeSizes();
+    this.defaultTypeSizesMap = DefaultTypeSizes.initDefaultTypeSizes();
   }
 
   private static final Map<String, Long> initDefaultTypeSizes() {
-    final URL csvFileURL = PreesmResourcesHelper.getInstance().resolve(CSV_FILE_UBUNTU_18_04_X64_GCC_7_4_0,
-        DefaultTypeSizes.class);
+    final URL csvFileURL = PreesmResourcesHelper.getInstance()
+        .resolve(DefaultTypeSizes.CSV_FILE_UBUNTU_18_04_X64_GCC_7_4_0, DefaultTypeSizes.class);
 
     if (csvFileURL == null) {
       throw new PreesmRuntimeException(
           "Could not locate CSV file storing default data type sizes (should be under 'resources/"
-              + CSV_FILE_UBUNTU_18_04_X64_GCC_7_4_0 + "' of plugin 'org.preesm.model.scenario'");
+              + DefaultTypeSizes.CSV_FILE_UBUNTU_18_04_X64_GCC_7_4_0 + "' of plugin 'org.preesm.model.scenario'");
     }
 
     try {
@@ -48,7 +48,7 @@ public final class DefaultTypeSizes {
         final String[] split = typeDef.split(":");
         res.put(split[0], Long.parseLong(split[1]));
       });
-      return res;
+      return Map.copyOf(res);
     } catch (final IOException e) {
       throw new PreesmRuntimeException("Could not read CSV file storing default data type sizes.", e);
     }
@@ -57,8 +57,8 @@ public final class DefaultTypeSizes {
   /**
    */
   public final long getDefaultTypeSize(final String typeName) {
-    if (this.defaultTypeSizes.containsKey(typeName)) {
-      return this.defaultTypeSizes.get(typeName);
+    if (this.defaultTypeSizesMap.containsKey(typeName)) {
+      return this.defaultTypeSizesMap.get(typeName);
     } else {
       return 1L;
     }

--- a/plugins/org.preesm.model.scenario/src/org/preesm/model/scenario/util/DefaultTypeSizes.java
+++ b/plugins/org.preesm.model.scenario/src/org/preesm/model/scenario/util/DefaultTypeSizes.java
@@ -1,0 +1,67 @@
+package org.preesm.model.scenario.util;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.preesm.commons.exceptions.PreesmRuntimeException;
+import org.preesm.commons.files.PreesmResourcesHelper;
+import org.preesm.commons.files.URLHelper;
+
+/**
+ *
+ *
+ * @author anmorvan
+ *
+ */
+public final class DefaultTypeSizes {
+
+  private static final DefaultTypeSizes instance = new DefaultTypeSizes();
+
+  private static final String CSV_FILE_UBUNTU_18_04_X64_GCC_7_4_0 = "default_type_sizes_ubuntu_18.04_x64_gcc_7.4.0.csv";
+
+  public static final DefaultTypeSizes getInstance() {
+    return instance;
+  }
+
+  private final Map<String, Long> defaultTypeSizes;
+
+  private DefaultTypeSizes() {
+    this.defaultTypeSizes = initDefaultTypeSizes();
+  }
+
+  private static final Map<String, Long> initDefaultTypeSizes() {
+    final URL csvFileURL = PreesmResourcesHelper.getInstance().resolve(CSV_FILE_UBUNTU_18_04_X64_GCC_7_4_0,
+        DefaultTypeSizes.class);
+
+    if (csvFileURL == null) {
+      throw new PreesmRuntimeException(
+          "Could not locate CSV file storing default data type sizes (should be under 'resources/"
+              + CSV_FILE_UBUNTU_18_04_X64_GCC_7_4_0 + "' of plugin 'org.preesm.model.scenario'");
+    }
+
+    try {
+      final String read = URLHelper.read(csvFileURL);
+      final Map<String, Long> res = new LinkedHashMap<>();
+      Arrays.stream(read.split("\n")).forEach(typeDef -> {
+        final String[] split = typeDef.split(":");
+        res.put(split[0], Long.parseLong(split[1]));
+      });
+      return res;
+    } catch (final IOException e) {
+      throw new PreesmRuntimeException("Could not read CSV file storing default data type sizes.", e);
+    }
+  }
+
+  /**
+   */
+  public final long getDefaultTypeSize(final String typeName) {
+    if (this.defaultTypeSizes.containsKey(typeName)) {
+      return this.defaultTypeSizes.get(typeName);
+    } else {
+      return 1L;
+    }
+  }
+
+}

--- a/plugins/org.preesm.ui.scenario/src/org/preesm/ui/scenario/editor/messages.properties
+++ b/plugins/org.preesm.ui.scenario/src/org/preesm/ui/scenario/editor/messages.properties
@@ -124,6 +124,7 @@ Simulation.DataTypes.addType=Add data type
 Simulation.DataTypes.addType.dialog.title=Enter data type name
 Simulation.DataTypes.addType.dialog.message=Enter a name for new data type\:
 Simulation.DataTypes.removeType=Remove data type
+Simulation.DataTypes.fetchType=Fetch all data types
 Simulation.DataAverageSize.title=Edit average transfer size
 Simulation.DataAverageSize.description=Set the average transfer size sizes in base unit (usually byte). This size is used while calculating the routing table. The routes between operators are static and will be optimized for the given data size.
 Simulation.SpecialVertex.title=Select the operators to execute broadcasts/explode/implode

--- a/plugins/org.preesm.ui.scenario/src/org/preesm/ui/scenario/editor/simulation/SimulationPage.java
+++ b/plugins/org.preesm.ui.scenario/src/org/preesm/ui/scenario/editor/simulation/SimulationPage.java
@@ -36,9 +36,12 @@
  */
 package org.preesm.ui.scenario.editor.simulation;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.ErrorDialog;
@@ -87,6 +90,7 @@ import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.ScrolledForm;
 import org.eclipse.ui.forms.widgets.Section;
 import org.preesm.commons.logger.PreesmLogger;
+import org.preesm.model.pisdf.Fifo;
 import org.preesm.model.scenario.Scenario;
 import org.preesm.model.scenario.ScenarioConstants;
 import org.preesm.model.scenario.impl.DataTypeImpl;
@@ -105,7 +109,13 @@ public class SimulationPage extends ScenarioPage {
   private static final String DATA_TYPE_SIZE_TITLE = Messages.getString("Simulation.DataTypes.sizeColumn");
   private static final String DATA_TYPE_NAME_TITLE = Messages.getString("Simulation.DataTypes.typeColumn");
 
-  private static final String[] DATA_TYPE_TABLE_TITLES = { DATA_TYPE_SIZE_TITLE, DATA_TYPE_NAME_TITLE };
+  private static final String[] DATA_TYPE_TABLE_TITLES = { DATA_TYPE_NAME_TITLE, DATA_TYPE_SIZE_TITLE };
+
+  static final Map<String,
+      Long> TYPE_MAP = Arrays
+          .stream(new Object[][] { { "char", 1L }, { "uchar", 1L }, { "void", 4L }, { "int", 4L }, { "float", 4L },
+              { "long", 8L }, { "double", 8L }, { "unsigned int", 4L }, { "unsigned long", 8L }, })
+          .collect(Collectors.toMap(kv -> (String) kv[0], kv -> (Long) kv[1]));
 
   /**
    * The listener interface for receiving comboBox events. The class that is interested in processing a comboBox event
@@ -417,10 +427,12 @@ public class SimulationPage extends ScenarioPage {
 
     // Buttons to add and remove data types
     final Composite buttonscps = toolkit.createComposite(parent);
-    buttonscps.setLayout(new GridLayout(2, true));
+    buttonscps.setLayout(new GridLayout(3, true));
     final Button addButton = toolkit.createButton(buttonscps, Messages.getString("Simulation.DataTypes.addType"),
         SWT.PUSH);
     final Button removeButton = toolkit.createButton(buttonscps, Messages.getString("Simulation.DataTypes.removeType"),
+        SWT.PUSH);
+    final Button fetchButton = toolkit.createButton(buttonscps, Messages.getString("Simulation.DataTypes.fetchType"),
         SWT.PUSH);
 
     final Composite tablecps = toolkit.createComposite(parent);
@@ -485,7 +497,7 @@ public class SimulationPage extends ScenarioPage {
 
       @Override
       public boolean canModify(final Object element, final String property) {
-        return property.contentEquals(DATA_TYPE_TABLE_TITLES[1]);
+        return property.contentEquals(DATA_TYPE_SIZE_TITLE);
       }
     });
     final Table tref = table;
@@ -503,8 +515,8 @@ public class SimulationPage extends ScenarioPage {
           final Point vBarSize = vBar.getSize();
           width -= vBarSize.x;
         }
-        columns[0].setWidth((width / 4) - 1);
-        columns[1].setWidth(width - columns[0].getWidth());
+        columns[1].setWidth(width / 4);
+        columns[0].setWidth(width - columns[1].getWidth());
         tref.setSize(area.width, area.height);
       }
     });
@@ -562,6 +574,28 @@ public class SimulationPage extends ScenarioPage {
         }
       }
     });
+
+    // Adding the new data type on click on add button
+    fetchButton.addSelectionListener(new SelectionAdapter() {
+
+      @Override
+      public void widgetSelected(final SelectionEvent e) {
+
+        for (Fifo f : scenario.getAlgorithm().getAllFifos()) {
+          String typeName = f.getType();
+          SimulationPage.this.scenario.getSimulationInfo().getDataTypes().put(typeName,
+              TYPE_MAP.getOrDefault(typeName, (long) ScenarioConstants.DEFAULT_DATA_TYPE_SIZE.getValue()));
+        }
+
+        tableViewer.refresh();
+        propertyChanged(SimulationPage.this, IEditorPart.PROP_DIRTY);
+        gd.heightHint = Math.max(50,
+            Math.min(300, SimulationPage.this.scenario.getSimulationInfo().getDataTypes().size() * 20 + 30));
+        tablecps.requestLayout();
+      }
+
+    });
+
   }
 
   /**

--- a/plugins/org.preesm.ui.scenario/src/org/preesm/ui/scenario/editor/simulation/SimulationPage.java
+++ b/plugins/org.preesm.ui.scenario/src/org/preesm/ui/scenario/editor/simulation/SimulationPage.java
@@ -36,12 +36,9 @@
  */
 package org.preesm.ui.scenario.editor.simulation;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.ErrorDialog;
@@ -94,6 +91,7 @@ import org.preesm.model.pisdf.Fifo;
 import org.preesm.model.scenario.Scenario;
 import org.preesm.model.scenario.ScenarioConstants;
 import org.preesm.model.scenario.impl.DataTypeImpl;
+import org.preesm.model.scenario.util.DefaultTypeSizes;
 import org.preesm.model.slam.ComponentInstance;
 import org.preesm.model.slam.Design;
 import org.preesm.ui.scenario.editor.Messages;
@@ -110,12 +108,6 @@ public class SimulationPage extends ScenarioPage {
   private static final String DATA_TYPE_NAME_TITLE = Messages.getString("Simulation.DataTypes.typeColumn");
 
   private static final String[] DATA_TYPE_TABLE_TITLES = { DATA_TYPE_NAME_TITLE, DATA_TYPE_SIZE_TITLE };
-
-  static final Map<String,
-      Long> TYPE_MAP = Arrays
-          .stream(new Object[][] { { "char", 1L }, { "uchar", 1L }, { "void", 4L }, { "int", 4L }, { "float", 4L },
-              { "long", 8L }, { "double", 8L }, { "unsigned int", 4L }, { "unsigned long", 8L }, })
-          .collect(Collectors.toMap(kv -> (String) kv[0], kv -> (Long) kv[1]));
 
   /**
    * The listener interface for receiving comboBox events. The class that is interested in processing a comboBox event
@@ -580,11 +572,10 @@ public class SimulationPage extends ScenarioPage {
 
       @Override
       public void widgetSelected(final SelectionEvent e) {
-
-        for (Fifo f : scenario.getAlgorithm().getAllFifos()) {
-          String typeName = f.getType();
+        for (final Fifo f : scenario.getAlgorithm().getAllFifos()) {
+          final String typeName = f.getType();
           SimulationPage.this.scenario.getSimulationInfo().getDataTypes().put(typeName,
-              TYPE_MAP.getOrDefault(typeName, (long) ScenarioConstants.DEFAULT_DATA_TYPE_SIZE.getValue()));
+              DefaultTypeSizes.getInstance().getDefaultTypeSize(typeName));
         }
 
         tableViewer.refresh();

--- a/release_notes.md
+++ b/release_notes.md
@@ -28,6 +28,9 @@ PREESM Changelog
   * Refactor memory allocation;
   * Rethrow all exceptions thrown by JEP with expression causing issue;
 * Add methods in PiSDFTopologyHelper, and corresponding tests;
+* Simulation tab of scenario now has an option to import all data types from
+  the graph, with predefined default values for common type names.
+
 
 ### Bug fix
 * Fix #74

--- a/tests/org.preesm.tests.model/src/org/preesm/tests/model/scenario/types/DefaultTypeSizesTest.java
+++ b/tests/org.preesm.tests.model/src/org/preesm/tests/model/scenario/types/DefaultTypeSizesTest.java
@@ -1,0 +1,33 @@
+package org.preesm.tests.model.scenario.types;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.preesm.model.scenario.util.DefaultTypeSizes;
+
+/**
+ *
+ * @author anmorvan
+ *
+ */
+public class DefaultTypeSizesTest {
+
+  @Test
+  public void testVoidTypeSize() {
+    final long defaultTypeSize = DefaultTypeSizes.getInstance().getDefaultTypeSize("void");
+    assertEquals(1L, defaultTypeSize);
+  }
+
+  @Test
+  public void testCharTypeSize() {
+    final long defaultTypeSize = DefaultTypeSizes.getInstance().getDefaultTypeSize("char");
+    assertEquals(1L, defaultTypeSize);
+  }
+
+  @Test
+  public void testINT32TTypeSize() {
+    final long defaultTypeSize = DefaultTypeSizes.getInstance().getDefaultTypeSize("int32_t");
+    assertEquals(4L, defaultTypeSize);
+  }
+
+}


### PR DESCRIPTION
Adds a new button in the data types section of simulation tab in scenario editor.

This button fetches and adds all data types listed in fifo of the graph (including refinements). A few default types are recognized, if not default size is put.