### PR TITLE
actor firing instances in PiMM model

### DIFF
--- a/plugins/org.preesm.model.pisdf/model/PiSDF.xcore
+++ b/plugins/org.preesm.model.pisdf/model/PiSDF.xcore
@@ -354,6 +354,7 @@ interface RefinementContainer {
 }
 
 class Actor extends ExecutableActor, RefinementContainer, PeriodicElement {
+	long firingInstance
 	String memoryScriptPath
 	op boolean isConfigurationActor() {
 		return configOutputPorts.map[outgoingDependencies].filter[!it.isEmpty].map[it.get(0)].map[getter].exists[true]

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/factory/PiMMUserFactory.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/factory/PiMMUserFactory.java
@@ -303,6 +303,7 @@ public final class PiMMUserFactory extends PiMMFactoryImpl implements PreesmUser
     final Actor res = super.createActor();
     final Expression exp = createExpression();
     res.setExpression(exp);
+    res.setFiringInstance(0L);
     return res;
   }
 

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/statictools/PiMMSRVerticesLinker.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/statictools/PiMMSRVerticesLinker.java
@@ -417,7 +417,7 @@ public class PiMMSRVerticesLinker {
     final boolean isSourceForkOrBroadcast = sourceVertex instanceof ForkActor || sourceVertex instanceof BroadcastActor;
     if (isSourceForkOrBroadcast) {
       // Update name and source port modifier
-      IntegerName iN = new IntegerName(srcDOP.size());
+      IntegerName iN = new IntegerName(srcDOP.size() - 1);
       final int index = srcDOP.indexOf(currentSourcePort);
       currentSourcePort.setName(currentSourcePort.getName() + "_" + iN.toString(index));
       currentSourcePort.setAnnotation(PortMemoryAnnotation.WRITE_ONLY);
@@ -454,7 +454,7 @@ public class PiMMSRVerticesLinker {
     final boolean isSinkJoinOrRoundBuffer = sinkVertex instanceof JoinActor || sinkVertex instanceof RoundBufferActor;
     if (isSinkJoinOrRoundBuffer) {
       // Update name and sink port modifier
-      IntegerName iN = new IntegerName(snkDOP.size());
+      IntegerName iN = new IntegerName(snkDOP.size() - 1);
       final int index = snkDOP.indexOf(currentSinkPort);
       currentSinkPort.setName(currentSinkPort.getName() + "_" + iN.toString(index));
       currentSinkPort.setAnnotation(PortMemoryAnnotation.READ_ONLY);
@@ -725,7 +725,7 @@ public class PiMMSRVerticesLinker {
         resultGraph.addActor(end);
         sinkSet.add(new SinkConnection(end, getterRate, this.sourcePort.getName()));
       } else {
-        IntegerName iN = new IntegerName(brvGetter);
+        IntegerName iN = new IntegerName(brvGetter - 1);
         for (long i = 0; i < brvGetter; ++i) {
           final EndActor end = PiMMUserFactory.instance.createEndActor();
           end.getDataInputPorts().add(PiMMUserFactory.instance.createDataInputPort());

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/statictools/PiSDFParameterResolverVisitor.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/statictools/PiSDFParameterResolverVisitor.java
@@ -58,6 +58,7 @@ import org.preesm.model.pisdf.ExpressionHolder;
 import org.preesm.model.pisdf.ISetter;
 import org.preesm.model.pisdf.InterfaceActor;
 import org.preesm.model.pisdf.Parameter;
+import org.preesm.model.pisdf.PeriodicElement;
 import org.preesm.model.pisdf.PiGraph;
 import org.preesm.model.pisdf.util.PiMMSwitch;
 
@@ -205,6 +206,11 @@ public class PiSDFParameterResolverVisitor extends PiMMSwitch<Boolean> {
       }
     }
     resolveActorPorts(actor, portValues);
+    // Resolve actor period
+    if (actor instanceof PeriodicElement) {
+      PeriodicElement pe = (PeriodicElement) actor;
+      resolveExpression(pe, portValues);
+    }
     return true;
   }
 
@@ -251,6 +257,9 @@ public class PiSDFParameterResolverVisitor extends PiMMSwitch<Boolean> {
 
     // Finally, we derive parameter values that have not already been processed
     computeDerivedParameterValues(graph, this.parameterValues);
+
+    // Resolve graph period
+    graph.setExpression(graph.getPeriod().evaluate());
 
     // We can now resolve data port rates for this graph
     for (final AbstractActor actor : graph.getOnlyActors()) {

--- a/plugins/org.preesm.ui.pisdf/src/org/preesm/ui/pisdf/util/SavePiGraph.java
+++ b/plugins/org.preesm.ui.pisdf/src/org/preesm/ui/pisdf/util/SavePiGraph.java
@@ -75,6 +75,10 @@ public class SavePiGraph {
   public static void save(final IProject iProject, final PiGraph graph, final String suffix) {
     final IPath targetFolder = FileUtils.browseFiles(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
         "Select result location", "Select the folder where to write the computed PiGraph.", (Collection<String>) null);
+    if (targetFolder == null) {
+      // the user canceled the save operation.
+      return;
+    }
     // The commented code is kept in case we would like to restrict the writing process to the given iProject.
 
     // final IPath inProjectPath = targetFolder.removeFirstSegments(1);

--- a/release_notes.md
+++ b/release_notes.md
@@ -11,6 +11,8 @@ PREESM Changelog
 * Refactor schedule order manager to use a graph internal representation for predecence;
 * Add schedule timer to compute timings (start/duration) for an actor;
 * PiSDF: use internal graph representation for topological operations;
+* Now firing instance number of any Actor can be stored in PiGraph model (set in SRDAG, not stored in .pi);
+
 
 ### Bug fix
 * Fix workflow task "org.ietr.preesm.pimm.algorithm.checker.periods.PeriodsPreschedulingChecker";


### PR DESCRIPTION
Adds firing instance number in the PiMM model, only for regular Actor. This can be particularly useful at the SRDAG level, and it is set automatically by the transformation.
However, firing instances are not stored in .pi since there is no semantics associated to it.