### PR TITLE
Hierarchy construction from a list of actors

### DIFF
--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/ClusteringBuilder.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/clustering/ClusteringBuilder.java
@@ -35,7 +35,6 @@
  */
 package org.preesm.algorithm.clustering;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -59,20 +58,14 @@ import org.preesm.commons.math.MathFunctionsHelper;
 import org.preesm.commons.model.PreesmCopyTracker;
 import org.preesm.model.pisdf.AbstractActor;
 import org.preesm.model.pisdf.AbstractVertex;
-import org.preesm.model.pisdf.ConfigInputInterface;
-import org.preesm.model.pisdf.ConfigInputPort;
-import org.preesm.model.pisdf.DataInputInterface;
-import org.preesm.model.pisdf.DataInputPort;
-import org.preesm.model.pisdf.DataOutputInterface;
-import org.preesm.model.pisdf.DataOutputPort;
 import org.preesm.model.pisdf.Delay;
-import org.preesm.model.pisdf.Dependency;
 import org.preesm.model.pisdf.Fifo;
 import org.preesm.model.pisdf.PiGraph;
 import org.preesm.model.pisdf.brv.BRVMethod;
 import org.preesm.model.pisdf.brv.PiBRV;
 import org.preesm.model.pisdf.check.PiGraphConsistenceChecker;
 import org.preesm.model.pisdf.factory.PiMMUserFactory;
+import org.preesm.model.pisdf.util.PiSDFSubgraphBuilder;
 import org.preesm.model.scenario.Scenario;
 import org.preesm.model.slam.Component;
 import org.preesm.model.slam.ComponentInstance;
@@ -297,7 +290,12 @@ public class ClusteringBuilder {
   private final Schedule clusterize(Pair<ScheduleType, List<AbstractActor>> actors) {
 
     // Build corresponding hierarchical actor
-    AbstractActor cluster = buildCluster(actors.getValue());
+    PiGraph cluster = new PiSDFSubgraphBuilder(pigraph, actors.getValue(), "cluster_" + nbCluster++).build();
+    cluster.setClusterValue(true);
+
+    for (ComponentInstance component : ClusteringHelper.getListOfCommonComponent(actors.getRight(), scenario)) {
+      scenario.getConstraints().addConstraint(component, cluster);
+    }
 
     // Build corresponding hierarchical schedule
     HierarchicalSchedule schedule = buildHierarchicalSchedule(actors);
@@ -345,7 +343,11 @@ public class ClusteringBuilder {
       repetitionVector = PiBRV.compute(pigraph, BRVMethod.LCM);
 
       // Build new cluster
-      PiGraph newCluster = buildCluster(childActors);
+      PiGraph newCluster = new PiSDFSubgraphBuilder(pigraph, childActors, "cluster_" + nbCluster++).build();
+      newCluster.setClusterValue(true);
+      for (ComponentInstance component : ClusteringHelper.getListOfCommonComponent(childActors, scenario)) {
+        scenario.getConstraints().addConstraint(component, newCluster);
+      }
       hierSchedule.setAttachedActor(newCluster);
     }
 
@@ -430,234 +432,6 @@ public class ClusteringBuilder {
       // Register in the schedule with original actor to be able to clusterize the non-copy graph
       schedule.getScheduleTree().add(outputSchedule);
     }
-  }
-
-  /**
-   * @param actors
-   *          list of actor to clusterize
-   * @return generated PiGraph connected with the parent graph
-   */
-  private final PiGraph buildCluster(List<AbstractActor> actors) {
-    // Create the cluster actor and set it name
-    PiGraph cluster = PiMMUserFactory.instance.createPiGraph();
-    cluster.setClusterValue(true);
-    cluster.setName("cluster_" + nbCluster++);
-    cluster.setUrl(pigraph.getUrl() + "/" + cluster.getName() + ".pi");
-
-    for (ComponentInstance component : ClusteringHelper.getListOfCommonComponent(actors, scenario)) {
-      scenario.getConstraints().addConstraint(component, cluster);
-    }
-
-    // Add cluster to the parent graph
-    pigraph.addActor(cluster);
-    for (AbstractActor actor : actors) {
-      cluster.addActor(actor);
-    }
-
-    // Export ports on cluster actor
-    manageClusteredActorsPort(actors, cluster);
-
-    return cluster;
-  }
-
-  private void manageClusteredActorsPort(List<AbstractActor> actors, PiGraph cluster) {
-
-    // Set to zero counters
-    int nbDataOutput = 0;
-    int nbDataInput = 0;
-    int nbConfigInput = 0;
-
-    // Compute clusterRepetition
-    long clusterRepetition = MathFunctionsHelper.gcd(CollectionUtil.mapGetAll(repetitionVector, actors));
-
-    for (AbstractActor actor : actors) {
-      // Retrieve actor repetition number
-      long actorRepetition = repetitionVector.get(actor);
-
-      // Attach DataInputPort on the cluster actor
-      for (DataInputPort dip : actor.getDataInputPorts()) {
-        nbDataInput = attachInputPort(actors, cluster, nbDataInput, clusterRepetition, actorRepetition, dip);
-      }
-
-      // Attach DataOutputPort on the cluster actor
-      for (DataOutputPort dop : actor.getDataOutputPorts()) {
-        nbDataOutput = attachOutputPort(actors, cluster, nbDataOutput, clusterRepetition, actorRepetition, dop);
-      }
-    }
-
-    // Attach ConfigInputPort on the cluster actor
-    List<ConfigInputPort> cfgipTmp = new ArrayList<>();
-    for (AbstractActor a : actors) {
-      cfgipTmp.addAll(a.getConfigInputPorts());
-    }
-    for (Delay delay : cluster.getAllDelays()) {
-      cfgipTmp.addAll(delay.getConfigInputPorts());
-      delay.setExpression(delay.getExpression().evaluate());
-    }
-    for (ConfigInputPort cfgip : cfgipTmp) {
-      setConfigInputPortAsInterface(cluster, cfgip, "config_" + nbConfigInput++);
-    }
-
-  }
-
-  private int attachOutputPort(List<AbstractActor> actors, PiGraph cluster, int nbDataOutput, long clusterRepetition,
-      long actorRepetition, DataOutputPort dop) {
-    // We only deport the output if FIFO is not internal
-    if (!actors.contains(dop.getOutgoingFifo().getTarget())) {
-      setDataOutputPortAsInterface(cluster, dop, "out_" + nbDataOutput++,
-          dop.getExpression().evaluate() * actorRepetition / clusterRepetition);
-    } else {
-      cluster.addFifo(dop.getOutgoingFifo());
-      Delay delay = dop.getOutgoingFifo().getDelay();
-      // If there is a delay, add it into the cluster
-      if (delay != null) {
-        cluster.addDelay(delay);
-      }
-    }
-    return nbDataOutput;
-  }
-
-  private int attachInputPort(List<AbstractActor> actors, PiGraph cluster, int nbDataInput, long clusterRepetition,
-      long actorRepetition, DataInputPort dip) {
-    // We only deport the input if FIFO is not internal
-    if (!actors.contains(dip.getIncomingFifo().getSource())) {
-      setDataInputPortAsInterface(cluster, dip, "in_" + nbDataInput++,
-          dip.getExpression().evaluate() * actorRepetition / clusterRepetition);
-    } else {
-      cluster.addFifo(dip.getIncomingFifo());
-      Delay delay = dip.getIncomingFifo().getDelay();
-      // If there is a delay, add it into the cluster
-      if (delay != null) {
-        cluster.addDelay(delay);
-      }
-    }
-    return nbDataInput;
-  }
-
-  /**
-   * @param cluster
-   *          cluster hierarchy
-   * @param insideInputPort
-   *          DataInputPort to connect outside
-   * @param name
-   *          name of port
-   * @param portExpression
-   *          prod/cons value
-   */
-  private final DataInputInterface setDataInputPortAsInterface(PiGraph cluster, DataInputPort insideInputPort,
-      String name, long portExpression) {
-    // Setup DataInputInterface
-    DataInputInterface inputInterface = PiMMUserFactory.instance.createDataInputInterface();
-    inputInterface.setName(name);
-    inputInterface.getDataPort().setName(name);
-    cluster.addActor(inputInterface);
-
-    // Setup input of hierarchical actor
-    DataInputPort inputPort = (DataInputPort) inputInterface.getGraphPort();
-    inputPort.setName(name); // same name than DataInputInterface
-    inputPort.setExpression(portExpression);
-
-    // Interconnect the outside with hierarchical actor
-    inputPort.setIncomingFifo(PiMMUserFactory.instance.createFifo());
-    cluster.getContainingPiGraph().addFifo(inputPort.getFifo());
-    Fifo oldFifo = insideInputPort.getFifo();
-    if (oldFifo.getDelay() != null) {
-      inputPort.getFifo().setDelay(oldFifo.getDelay());
-    }
-    String dataType = oldFifo.getType();
-    inputPort.getIncomingFifo().setSourcePort(oldFifo.getSourcePort());
-    inputPort.getIncomingFifo().setType(dataType);
-    cluster.getContainingPiGraph().removeFifo(oldFifo); // remove FIFO from containing graph
-
-    // Setup inside communication with DataInputInterface
-    DataOutputPort outputDataPort = (DataOutputPort) inputInterface.getDataPort();
-    outputDataPort.setExpression(portExpression);
-    outputDataPort.setOutgoingFifo(PiMMUserFactory.instance.createFifo());
-    outputDataPort.getOutgoingFifo().setTargetPort(insideInputPort);
-    outputDataPort.getOutgoingFifo().setType(dataType);
-    inputInterface.getDataOutputPorts().add(outputDataPort);
-    cluster.addFifo(outputDataPort.getFifo());
-
-    return inputInterface;
-  }
-
-  /**
-   * @param cluster
-   *          cluster hierarchy
-   * @param insideOutputPort
-   *          DataOutputPort to connect outside
-   * @param name
-   *          name of port
-   * @param portExpression
-   *          prod/cons value
-   */
-  private final DataOutputInterface setDataOutputPortAsInterface(PiGraph cluster, DataOutputPort insideOutputPort,
-      String name, long portExpression) {
-    // Setup DataOutputInterface
-    DataOutputInterface outputInterface = PiMMUserFactory.instance.createDataOutputInterface();
-    outputInterface.setName(name);
-    outputInterface.getDataPort().setName(name);
-    cluster.addActor(outputInterface);
-
-    // Setup output of hierarchical actor
-    DataOutputPort outputPort = (DataOutputPort) outputInterface.getGraphPort();
-    outputPort.setName(name); // same name than DataOutputInterface
-    outputPort.setExpression(portExpression);
-
-    // Interconnect the outside with hierarchical actor
-    outputPort.setOutgoingFifo(PiMMUserFactory.instance.createFifo());
-    cluster.getContainingPiGraph().addFifo(outputPort.getFifo());
-    Fifo oldFifo = insideOutputPort.getFifo();
-    if (oldFifo.getDelay() != null) {
-      outputPort.getFifo().setDelay(oldFifo.getDelay());
-    }
-    String dataType = oldFifo.getType();
-    outputPort.getOutgoingFifo().setTargetPort(oldFifo.getTargetPort());
-    outputPort.getOutgoingFifo().setType(dataType);
-    cluster.getContainingPiGraph().removeFifo(oldFifo); // remove FIFO from containing graph
-
-    // Setup inside communication with DataOutputInterface
-    DataInputPort inputDataPort = (DataInputPort) outputInterface.getDataPort();
-    inputDataPort.setExpression(portExpression);
-    inputDataPort.setIncomingFifo(PiMMUserFactory.instance.createFifo());
-    inputDataPort.getIncomingFifo().setSourcePort(insideOutputPort);
-    inputDataPort.getIncomingFifo().setType(dataType);
-    outputInterface.getDataInputPorts().add(inputDataPort);
-    cluster.addFifo(inputDataPort.getFifo());
-
-    return outputInterface;
-  }
-
-  /**
-   * @param cluster
-   *          new hierarchy
-   * @param insideInputPort
-   *          ConfigInputPort to connect outside
-   * @return generated ConfigInputInterface
-   */
-  private final ConfigInputInterface setConfigInputPortAsInterface(PiGraph cluster, ConfigInputPort insideInputPort,
-      String name) {
-    // Setup ConfigInputInterface
-    ConfigInputInterface inputInterface = PiMMUserFactory.instance.createConfigInputInterface();
-    inputInterface.setName(name);
-    cluster.addParameter(inputInterface);
-
-    // Setup input of hierarchical actor
-    ConfigInputPort inputPort = inputInterface.getGraphPort();
-    inputPort.setName(name); // same name than ConfigInputInterface
-
-    // Interconnect the outside with hierarchical actor
-    inputPort.setIncomingDependency(PiMMUserFactory.instance.createDependency());
-    cluster.getContainingPiGraph().addDependency(inputPort.getIncomingDependency());
-    Dependency oldDependency = insideInputPort.getIncomingDependency();
-    inputPort.getIncomingDependency().setSetter(oldDependency.getSetter());
-
-    // Setup inside communication with ConfigInputInterface
-    Dependency dependency = insideInputPort.getIncomingDependency();
-    dependency.setSetter(inputInterface);
-    cluster.addDependency(dependency);
-
-    return inputInterface;
   }
 
 }

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiSDFSubgraphBuilder.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiSDFSubgraphBuilder.java
@@ -1,0 +1,235 @@
+package org.preesm.model.pisdf.util;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import org.preesm.commons.CollectionUtil;
+import org.preesm.commons.math.MathFunctionsHelper;
+import org.preesm.model.pisdf.AbstractActor;
+import org.preesm.model.pisdf.AbstractVertex;
+import org.preesm.model.pisdf.ConfigInputInterface;
+import org.preesm.model.pisdf.ConfigInputPort;
+import org.preesm.model.pisdf.DataInputInterface;
+import org.preesm.model.pisdf.DataInputPort;
+import org.preesm.model.pisdf.DataOutputInterface;
+import org.preesm.model.pisdf.DataOutputPort;
+import org.preesm.model.pisdf.Delay;
+import org.preesm.model.pisdf.Dependency;
+import org.preesm.model.pisdf.Fifo;
+import org.preesm.model.pisdf.PiGraph;
+import org.preesm.model.pisdf.Port;
+import org.preesm.model.pisdf.brv.BRVMethod;
+import org.preesm.model.pisdf.brv.PiBRV;
+import org.preesm.model.pisdf.check.PiGraphConsistenceChecker;
+import org.preesm.model.pisdf.factory.PiMMUserFactory;
+
+/**
+ * @author dgageot
+ * 
+ *         Build a subgraph from given actors.
+ *
+ */
+public class PiSDFSubgraphBuilder extends PiMMSwitch<Boolean> {
+
+  private final List<AbstractActor> subGraphActors;
+
+  private final PiGraph parentGraph;
+
+  private final PiGraph subGraph;
+
+  private List<Fifo> visitedFifo;
+
+  private int nbInputInterface;
+
+  private int nbOutputInterface;
+
+  private int nbInputCfgInterface;
+
+  private final Map<AbstractVertex, Long> repetitionVector;
+
+  private final long subGraphRepetition;
+
+  /**
+   * @param parentGraph
+   *          parent graph
+   * @param subGraphActors
+   *          subgraph actors
+   * @param subGraphName
+   *          subgraph name
+   */
+  public PiSDFSubgraphBuilder(PiGraph parentGraph, List<AbstractActor> subGraphActors, String subGraphName) {
+    this.parentGraph = parentGraph;
+    this.subGraphActors = new LinkedList<>(subGraphActors);
+    this.subGraph = PiMMUserFactory.instance.createPiGraph();
+    this.subGraph.setName(subGraphName);
+    this.subGraph.setUrl(this.parentGraph.getUrl() + "/" + subGraphName + ".pi");
+    this.visitedFifo = new LinkedList<>();
+    this.nbInputInterface = 0;
+    this.nbOutputInterface = 0;
+    this.nbInputCfgInterface = 0;
+    this.repetitionVector = PiBRV.compute(parentGraph, BRVMethod.TOPOLOGY);
+    this.subGraphRepetition = MathFunctionsHelper.gcd(CollectionUtil.mapGetAll(repetitionVector, subGraphActors));
+  }
+
+  /**
+   * @return resulting subgraph
+   */
+  public PiGraph build() {
+    // Add subgraph to parent graph
+    this.parentGraph.addActor(subGraph);
+    // Add actors to the new subgraph
+    for (AbstractActor actor : this.subGraphActors) {
+      doSwitch(actor);
+    }
+    // Check consistency of parent graph
+    PiGraphConsistenceChecker.check(this.parentGraph);
+    return this.subGraph;
+  }
+
+  @Override
+  public Boolean caseAbstractActor(AbstractActor object) {
+    this.subGraph.addActor(object);
+    for (Port port : object.getAllPorts()) {
+      doSwitch(port);
+    }
+    return super.caseAbstractActor(object);
+  }
+
+  @Override
+  public Boolean caseDataInputPort(DataInputPort object) {
+    // If caseFifo returns true, it means that the port lead to an actor outside the subgraph
+    if (doSwitch(object.getFifo())) {
+      // Setup the input interface
+      DataInputInterface inputInterface = PiMMUserFactory.instance.createDataInputInterface();
+      String inputName = "in_" + this.nbInputInterface++;
+      inputInterface.setName(inputName);
+      inputInterface.getDataPort().setName(inputName);
+      this.subGraph.addActor(inputInterface);
+
+      // Setup input of hierarchical actor
+      DataInputPort inputPort = (DataInputPort) inputInterface.getGraphPort();
+      inputPort.setName(inputName); // same name than DataInputInterface
+      // Compute port expression
+      long actorRepetition = this.repetitionVector.get(object.getContainingActor());
+      long portExpression = object.getExpression().evaluate() * actorRepetition / this.subGraphRepetition;
+      inputPort.setExpression(portExpression);
+
+      // Interconnect the outside with hierarchical actor
+      Fifo incomingFifo = PiMMUserFactory.instance.createFifo();
+      inputPort.setIncomingFifo(incomingFifo);
+      this.parentGraph.addFifo(incomingFifo);
+      Fifo oldFifo = object.getFifo();
+      Delay oldDelay = oldFifo.getDelay();
+      if (oldDelay != null) {
+        incomingFifo.setDelay(oldDelay);
+      }
+      String dataType = oldFifo.getType();
+      incomingFifo.setSourcePort(oldFifo.getSourcePort());
+      incomingFifo.setType(dataType);
+      this.parentGraph.removeFifo(oldFifo); // remove FIFO from containing graph
+
+      // Setup inside communication with DataInputInterface
+      DataOutputPort outputPort = (DataOutputPort) inputInterface.getDataPort();
+      outputPort.setExpression(portExpression);
+      Fifo insideOutgoingFifo = PiMMUserFactory.instance.createFifo();
+      outputPort.setOutgoingFifo(insideOutgoingFifo);
+      insideOutgoingFifo.setTargetPort(object);
+      insideOutgoingFifo.setType(dataType);
+      inputInterface.getDataOutputPorts().add(outputPort);
+      this.subGraph.addFifo(insideOutgoingFifo);
+    }
+    return super.caseDataInputPort(object);
+  }
+
+  @Override
+  public Boolean caseDataOutputPort(DataOutputPort object) {
+    // If caseFifo returns true, it means that the port lead to an actor outside the subgraph
+    if (doSwitch(object.getFifo())) {
+      // Setup the output interface
+      DataOutputInterface outputInterface = PiMMUserFactory.instance.createDataOutputInterface();
+      String outputName = "out_" + this.nbOutputInterface++;
+      outputInterface.setName(outputName);
+      outputInterface.getDataPort().setName(outputName);
+      this.subGraph.addActor(outputInterface);
+
+      // Setup output of hierarchical actor
+      DataOutputPort outputPort = (DataOutputPort) outputInterface.getGraphPort();
+      outputPort.setName(outputName); // same name than DataOutputInterface
+      // Compute port expression
+      long actorRepetition = this.repetitionVector.get(object.getContainingActor());
+      long portExpression = object.getExpression().evaluate() * actorRepetition / this.subGraphRepetition;
+      outputPort.setExpression(portExpression);
+
+      // Interconnect the outside with hierarchical actor
+      Fifo outsideOutgoingFifo = PiMMUserFactory.instance.createFifo();
+      outputPort.setOutgoingFifo(outsideOutgoingFifo);
+      this.parentGraph.addFifo(outsideOutgoingFifo);
+      Fifo oldFifo = object.getFifo();
+      Delay oldDelay = oldFifo.getDelay();
+      if (oldDelay != null) {
+        outsideOutgoingFifo.setDelay(oldDelay);
+      }
+      String dataType = oldFifo.getType();
+      outsideOutgoingFifo.setTargetPort(oldFifo.getTargetPort());
+      outsideOutgoingFifo.setType(dataType);
+      this.parentGraph.removeFifo(oldFifo); // remove FIFO from containing graph
+
+      // Setup inside communication with DataOutputInterface
+      DataInputPort inputDataPort = (DataInputPort) outputInterface.getDataPort();
+      inputDataPort.setExpression(portExpression);
+      Fifo insideIncomingFifo = PiMMUserFactory.instance.createFifo();
+      inputDataPort.setIncomingFifo(insideIncomingFifo);
+      insideIncomingFifo.setSourcePort(object);
+      insideIncomingFifo.setType(dataType);
+      outputInterface.getDataInputPorts().add(inputDataPort);
+      this.subGraph.addFifo(insideIncomingFifo);
+    }
+    return super.caseDataOutputPort(object);
+  }
+
+  @Override
+  public Boolean caseConfigInputPort(ConfigInputPort object) {
+    // Setup the input configuration interface
+    ConfigInputInterface inputInterface = PiMMUserFactory.instance.createConfigInputInterface();
+    String inputCfgName = "cfg_" + this.nbInputCfgInterface++;
+    inputInterface.setName(inputCfgName);
+    this.subGraph.addParameter(inputInterface);
+
+    // Setup input of hierarchical actor
+    ConfigInputPort inputPort = inputInterface.getGraphPort();
+    inputPort.setName(inputCfgName); // same name than ConfigInputInterface
+
+    // Interconnect the outside with hierarchical actor
+    Dependency outsideIncomingDependency = PiMMUserFactory.instance.createDependency();
+    inputPort.setIncomingDependency(outsideIncomingDependency);
+    this.parentGraph.addDependency(outsideIncomingDependency);
+    Dependency oldDependency = object.getIncomingDependency();
+    outsideIncomingDependency.setSetter(oldDependency.getSetter());
+
+    // Setup inside communication with ConfigInputInterface
+    Dependency dependency = object.getIncomingDependency();
+    dependency.setSetter(inputInterface);
+    this.subGraph.addDependency(dependency);
+
+    return super.caseConfigInputPort(object);
+  }
+
+  @Override
+  public Boolean caseFifo(Fifo object) {
+    // Is the fifo connect two actors of the desired subgraph?
+    boolean betweenActorsOfSubGraph = this.subGraphActors.contains(object.getTarget())
+        && this.subGraphActors.contains(object.getSource());
+    // If fifo should be contained in the subgraph, add it.
+    if (betweenActorsOfSubGraph && !this.visitedFifo.contains(object)) {
+      this.visitedFifo.add(object);
+      this.subGraph.addFifo(object);
+      Delay delay = object.getDelay();
+      // If there is a delay, add it into the subgraph
+      if (delay != null) {
+        this.subGraph.addDelay(delay);
+      }
+    }
+    return !betweenActorsOfSubGraph;
+  }
+
+}

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiSDFSubgraphBuilder.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiSDFSubgraphBuilder.java
@@ -24,42 +24,71 @@ import org.preesm.model.pisdf.check.PiGraphConsistenceChecker;
 import org.preesm.model.pisdf.factory.PiMMUserFactory;
 
 /**
- * @author dgageot
+ * This class is used to build a subgraph from given list of actors.
  * 
- *         Build a subgraph from given actors.
- *
+ * @author dgageot
  */
 public class PiSDFSubgraphBuilder extends PiMMSwitch<Boolean> {
 
+  /**
+   * Actors that compose the subgraph.
+   */
   private final List<AbstractActor> subGraphActors;
 
+  /**
+   * Parent graph of the subgraph.
+   */
   private final PiGraph parentGraph;
 
+  /**
+   * Subgraph builded with this class.
+   */
   private final PiGraph subGraph;
 
+  /**
+   * List of visited Fifo in order to explore the PiGraph.
+   */
   private List<Fifo> visitedFifo;
 
+  /**
+   * Number of input interface of builded subgraph.
+   */
   private int nbInputInterface;
 
+  /**
+   * Number of output interface of builded subgraph.
+   */
   private int nbOutputInterface;
 
+  /**
+   * Number of input configuration interface of builded subgraph.
+   */
   private int nbInputCfgInterface;
 
+  /**
+   * Repetition vector of input graph.
+   */
   private final Map<AbstractVertex, Long> repetitionVector;
 
+  /**
+   * Repetition count of the subgraph.
+   */
   private final long subGraphRepetition;
 
   /**
+   * Builds a PiSDFSubgraphBuilder object.
+   * 
    * @param parentGraph
-   *          parent graph
+   *          The parent graph.
    * @param subGraphActors
-   *          subgraph actors
+   *          The list of actors that will compose the subgraph.
    * @param subGraphName
-   *          subgraph name
+   *          The name of the subgraph.
    */
   public PiSDFSubgraphBuilder(PiGraph parentGraph, List<AbstractActor> subGraphActors, String subGraphName) {
     this.parentGraph = parentGraph;
     this.subGraphActors = new LinkedList<>(subGraphActors);
+    // Create a PiGraph for the subgraph
     this.subGraph = PiMMUserFactory.instance.createPiGraph();
     this.subGraph.setName(subGraphName);
     this.subGraph.setUrl(this.parentGraph.getUrl() + "/" + subGraphName + ".pi");
@@ -67,12 +96,16 @@ public class PiSDFSubgraphBuilder extends PiMMSwitch<Boolean> {
     this.nbInputInterface = 0;
     this.nbOutputInterface = 0;
     this.nbInputCfgInterface = 0;
-    this.repetitionVector = PiBRV.compute(parentGraph, BRVMethod.TOPOLOGY);
+    // Compute BRV for the parent graph
+    this.repetitionVector = PiBRV.compute(parentGraph, BRVMethod.LCM);
+    // Compute repetition count of the subgraph with great common divisor over all subgraph actors repetition counts
     this.subGraphRepetition = MathFunctionsHelper.gcd(CollectionUtil.mapGetAll(repetitionVector, subGraphActors));
   }
 
   /**
-   * @return resulting subgraph
+   * Performs subgraph actors extraction from parent graph.
+   * 
+   * @return The resulting PiGraph with the desired subgraph.
    */
   public PiGraph build() {
     // Add subgraph to parent graph

--- a/release_notes.md
+++ b/release_notes.md
@@ -16,6 +16,8 @@ PREESM Changelog
 *2019.11.28*
 
 ### New Feature
+* PiSDF:
+	* Hierarchy construction from a list of actors (PiSDFSubgraphBuilder)
 
 ### Changes
 * Graph period has been added to the PiGraph model and appears in the UI;

--- a/tests/org.preesm.tests.model/META-INF/MANIFEST.MF
+++ b/tests/org.preesm.tests.model/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Require-Bundle: org.junit;bundle-version="4.12.0",
 Export-Package: org.ietr.preesm.architecture.test,
  org.preesm.model.pisdf.test,
  org.preesm.model.slam.test
+Import-Package: org.eclipse.core.resources

--- a/tests/org.preesm.tests.model/src/org/preesm/model/pisdf/test/PiSDFSubgraphBuilderTest.java
+++ b/tests/org.preesm.tests.model/src/org/preesm/model/pisdf/test/PiSDFSubgraphBuilderTest.java
@@ -110,6 +110,22 @@ public class PiSDFSubgraphBuilderTest {
     Assert.assertEquals(fifoAB.getDelay().getActor().getContainingPiGraph(), topGraph);
   }
 
+  @Test
+  public void testDataInputPortsOfSubGraph() {
+    Assert.assertEquals(subGraph.getDataInputPorts().size(), 1);
+    DataInputPort dipSubGraph = subGraph.getDataInputPorts().get(0);
+    Assert.assertTrue(dipSubGraph.getName().contains("in_0"));
+    Assert.assertEquals(dipSubGraph.getExpression().evaluate(), 2);
+  }
+
+  @Test
+  public void testDataOutputPortsOfSubGraph() {
+    Assert.assertEquals(subGraph.getDataOutputPorts().size(), 1);
+    DataOutputPort dopSubGraph = subGraph.getDataOutputPorts().get(0);
+    Assert.assertTrue(dopSubGraph.getName().contains("out_0"));
+    Assert.assertEquals(dopSubGraph.getExpression().evaluate(), 2);
+  }
+
   private PiGraph createChainedActorsPiGraph() {
     // Create the top graph
     PiGraph topGraph = PiMMUserFactory.instance.createPiGraph();

--- a/tests/org.preesm.tests.model/src/org/preesm/model/pisdf/test/PiSDFSubgraphBuilderTest.java
+++ b/tests/org.preesm.tests.model/src/org/preesm/model/pisdf/test/PiSDFSubgraphBuilderTest.java
@@ -1,0 +1,186 @@
+package org.preesm.model.pisdf.test;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.preesm.model.pisdf.AbstractActor;
+import org.preesm.model.pisdf.ConfigInputPort;
+import org.preesm.model.pisdf.DataInputPort;
+import org.preesm.model.pisdf.DataOutputPort;
+import org.preesm.model.pisdf.Delay;
+import org.preesm.model.pisdf.DelayActor;
+import org.preesm.model.pisdf.Dependency;
+import org.preesm.model.pisdf.Fifo;
+import org.preesm.model.pisdf.Parameter;
+import org.preesm.model.pisdf.PiGraph;
+import org.preesm.model.pisdf.factory.PiMMUserFactory;
+import org.preesm.model.pisdf.util.PiSDFSubgraphBuilder;
+
+/**
+ * This class is used to test the PiSDFSubgraphBuilder class.
+ * 
+ * @author dgageot
+ *
+ */
+public class PiSDFSubgraphBuilderTest {
+
+  public PiGraph       topGraph;
+  public PiGraph       subGraph;
+  public AbstractActor actorA;
+  public AbstractActor actorB;
+  public AbstractActor actorC;
+  public AbstractActor actorD;
+  public Parameter     param;
+
+  /**
+   * Sets-up the test environnement
+   */
+  @Before
+  public void setUp() {
+    // Create a chained actors PiGraph and lookup for actors B and C
+    this.topGraph = createChainedActorsPiGraph();
+    this.actorA = (AbstractActor) topGraph.lookupAllVertex("A");
+    this.actorB = (AbstractActor) topGraph.lookupAllVertex("B");
+    this.actorC = (AbstractActor) topGraph.lookupAllVertex("C");
+    this.actorD = (AbstractActor) topGraph.lookupAllVertex("D");
+    this.param = topGraph.lookupParameterGivenGraph("useless", "topgraph");
+    // Regroup the two reference in a list
+    List<AbstractActor> subGraphActors = Arrays.asList(actorB, actorC);
+    // Build a PiSDFSubgraphBuilder
+    PiSDFSubgraphBuilder subgraphBuilder = new PiSDFSubgraphBuilder(topGraph, subGraphActors, "B_C");
+    // Process the transformation
+    subgraphBuilder.build();
+    // Keep a reference to the builded subgraph
+    this.subGraph = (PiGraph) topGraph.lookupAllVertex("B_C");
+  }
+
+  /**
+   * Teardowns the test environnement
+   */
+  @After
+  public void tearDown() {
+    this.topGraph = null;
+    this.actorA = null;
+    this.actorB = null;
+    this.actorC = null;
+    this.actorD = null;
+    this.param = null;
+    this.subGraph = null;
+  }
+
+  @Test
+  public void testExistenceOfSubGraph() {
+    // Check if the subgraph has been found in top graph
+    Assert.assertNotNull(subGraph);
+  }
+
+  @Test
+  public void testNameOfSubGraph() {
+    // Check if the subgraph is called "B_C"
+    Assert.assertEquals(subGraph.getName(), "B_C");
+  }
+
+  @Test
+  public void testActorsContainedInSubGraph() {
+    // Check if the subgraph contains actors B and C
+    Assert.assertTrue(subGraph.getActors().contains(actorB));
+    Assert.assertTrue(subGraph.getActors().contains(actorC));
+  }
+
+  @Test
+  public void testFifoContainedInSubGraph() {
+    // Check if the fifo that link B to C is contained
+    Fifo fifoBC = actorB.getDataOutputPorts().get(0).getFifo();
+    Assert.assertEquals(fifoBC.getContainingPiGraph(), subGraph);
+    // Check that the delay and its actor is contained in the subgraph
+    Assert.assertEquals(fifoBC.getDelay().getContainingPiGraph(), subGraph);
+    Assert.assertEquals(fifoBC.getDelay().getActor().getContainingPiGraph(), subGraph);
+  }
+
+  @Test
+  public void testFifoOutsideOfSubGraph() {
+    // Check that outside delay are still outside
+    Fifo fifoAB = actorA.getDataOutputPorts().get(0).getFifo();
+    Assert.assertEquals(fifoAB.getContainingPiGraph(), topGraph);
+    // Check that the delay and its actor is contained in the top graph
+    Assert.assertEquals(fifoAB.getDelay().getContainingPiGraph(), topGraph);
+    Assert.assertEquals(fifoAB.getDelay().getActor().getContainingPiGraph(), topGraph);
+  }
+
+  private PiGraph createChainedActorsPiGraph() {
+    // Create the top graph
+    PiGraph topGraph = PiMMUserFactory.instance.createPiGraph();
+    topGraph.setName("topgraph");
+    topGraph.setUrl("topgraph");
+    // Create 4 actors
+    AbstractActor actorA = PiMMUserFactory.instance.createActor("A");
+    AbstractActor actorB = PiMMUserFactory.instance.createActor("B");
+    AbstractActor actorC = PiMMUserFactory.instance.createActor("C");
+    AbstractActor actorD = PiMMUserFactory.instance.createActor("D");
+    // Create a list for the 4 actors to easily add them to the top graph
+    List<AbstractActor> actorsList = Arrays.asList(actorA, actorB, actorC, actorD);
+    // Add actors to the top graph
+    for (AbstractActor actor : actorsList) {
+      topGraph.addActor(actor);
+    }
+    // Create data output and input ports
+    DataOutputPort outputA = PiMMUserFactory.instance.createDataOutputPort("out");
+    DataOutputPort outputB = PiMMUserFactory.instance.createDataOutputPort("out");
+    DataOutputPort outputC = PiMMUserFactory.instance.createDataOutputPort("out");
+    DataInputPort inputB = PiMMUserFactory.instance.createDataInputPort("in");
+    DataInputPort inputC = PiMMUserFactory.instance.createDataInputPort("in");
+    DataInputPort inputD = PiMMUserFactory.instance.createDataInputPort("in");
+    // Attach them to actors
+    actorA.getDataOutputPorts().add(outputA);
+    actorB.getDataOutputPorts().add(outputB);
+    actorC.getDataOutputPorts().add(outputC);
+    actorB.getDataInputPorts().add(inputB);
+    actorC.getDataInputPorts().add(inputC);
+    actorD.getDataInputPorts().add(inputD);
+    // Create fifos and form a chain such as A -> B -> C -> D
+    Fifo fifoAB = PiMMUserFactory.instance.createFifo(outputA, inputB, "void");
+    Fifo fifoBC = PiMMUserFactory.instance.createFifo(outputB, inputC, "void");
+    Fifo fifoCD = PiMMUserFactory.instance.createFifo(outputC, inputD, "void");
+    // Create a list for the 3 fifos to easily add them to the top graph
+    List<Fifo> fifosList = Arrays.asList(fifoAB, fifoBC, fifoCD);
+    // Add fifos to the top graph
+    for (Fifo fifo : fifosList) {
+      topGraph.addFifo(fifo);
+    }
+    // Setup data output and input ports rates
+    // Repetition vector should be equal to [1, 8, 8, 2]'
+    outputA.setExpression(16);
+    inputB.setExpression(2);
+    outputB.setExpression(2);
+    inputC.setExpression(2);
+    outputC.setExpression(2);
+    inputD.setExpression(8);
+    // Set delay to fifo BC
+    Delay delayBC = PiMMUserFactory.instance.createDelay();
+    @SuppressWarnings("unused")
+    DelayActor delayActorBC = PiMMUserFactory.instance.createDelayActor(delayBC);
+    delayBC.setExpression(2);
+    fifoBC.setDelay(delayBC);
+    topGraph.addDelay(delayBC);
+    // Set delay to fifo AC
+    Delay delayAC = PiMMUserFactory.instance.createDelay();
+    @SuppressWarnings("unused")
+    DelayActor delayActorAB = PiMMUserFactory.instance.createDelayActor(delayAC);
+    delayAC.setExpression(16);
+    fifoAB.setDelay(delayAC);
+    topGraph.addDelay(delayAC);
+    // Add a parameter to actor B
+    Parameter parameter = PiMMUserFactory.instance.createParameter("useless", 2);
+    ConfigInputPort configInputB = PiMMUserFactory.instance.createConfigInputPort();
+    actorB.getConfigInputPorts().add(configInputB);
+    Dependency dependency = PiMMUserFactory.instance.createDependency(parameter, configInputB);
+    topGraph.addParameter(parameter);
+    topGraph.addDependency(dependency);
+    // Return top graph
+    return topGraph;
+  }
+
+}


### PR DESCRIPTION
This Pull Request introduces the PiSDFSubgraphBuilder class. This class is used to build a hierarchy from a list of actors of top graph. It does not check for deadlocks after construction but it does check for consistency. 

This feature was already developed for clustering purposes, I did some refactor and put it in a PiSDF visitor class in order to clean up the code. Unit tests has been added.

NB: ConfigOutputPorts/Interfaces and delay getters/setters are not currently supported. Further discussions would be necessary to implement a correct solution based on these concepts.