### PR TITLE
Improve evaluation of parameters if Number

### DIFF
--- a/plugins/org.preesm.commons/src/org/preesm/commons/math/functions/AbstractPreesmMathFunction.java
+++ b/plugins/org.preesm.commons/src/org/preesm/commons/math/functions/AbstractPreesmMathFunction.java
@@ -68,11 +68,12 @@ public abstract class AbstractPreesmMathFunction extends PostfixMathCommand {
     final double[] args = new double[getArgCount()];
     for (int i = 0; i < getArgCount(); i++) {
       final Object arg = stack.pop();
-      if (!(arg instanceof Double)) {
+      if (!(arg instanceof Number)) {
         throw new ParseException(
             "Argument must be a number, whereas it is " + arg + "(" + arg.getClass().getName() + ")");
       }
-      args[i] = (double) arg;
+      Number nb = (Number) arg;
+      args[i] = nb.doubleValue();
     }
     final double result = compute(args);
     stack.push(result);

--- a/release_notes.md
+++ b/release_notes.md
@@ -20,14 +20,14 @@ PREESM Changelog
   closure and improves performanes.
 
 ### Bug fix
-* Fix #271: removes extra coma in spider codegen when no parameters.
-* Fix #262
-* Fix #264
-* Fix #267
-* Fix #268
-* Fix #269
-* Fix #273
-
+* Fix #271 : removes extra coma in spider codegen when no parameters.
+* Fix #262 : (codegen) init functions are now called only once
+* Fix #264 : Excel timings can handle expression, not only numbers
+* Fix #267 : remove useless and bugged 'set fifo type' GUI feature
+* Fix #268 : uniformize GUI features command order and names 
+* Fix #269 : improve the lookup method by vertex path
+* Fix #273 : BRV computation was not adapted to port rates being 0 (see Changes section)
+* Fix evaluation of parameters as numbers.
 
 ## Release version 3.18.2
 *2019.11.28*


### PR DESCRIPTION
Add details in release notes and fix bug about parameters.

After merging this PR, you can remove the following branches:

    branch optimizeCommunicationInsertion (problem fixed by PR 278)
    branch periodicScheduler (the one of this PR)
    branch subgraphBuilder (already merged, see PR 279)

I think a new release can be built once this PR is merged (with middle version number increment).