### PR TITLE
Add a class to seek for Uniform Repetition Count structure in PiGraph

### DIFF
--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/URCSeeker.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/URCSeeker.java
@@ -4,7 +4,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import org.preesm.model.pisdf.AbstractActor;
-import org.preesm.model.pisdf.DataOutputPort;
+import org.preesm.model.pisdf.ExecutableActor;
 import org.preesm.model.pisdf.Fifo;
 import org.preesm.model.pisdf.PiGraph;
 
@@ -47,7 +47,7 @@ public class URCSeeker extends PiMMSwitch<Boolean> {
     // Clear the list of identified URCs
     this.identifiedURCs.clear();
     // Explore all actors of the graph
-    this.graph.getActors().forEach(x -> doSwitch(x));
+    this.graph.getActors().stream().filter(x -> x instanceof ExecutableActor).forEach(x -> doSwitch(x));
     // Return identified URCs
     return identifiedURCs;
   }
@@ -56,8 +56,7 @@ public class URCSeeker extends PiMMSwitch<Boolean> {
   public Boolean caseAbstractActor(AbstractActor actor) {
 
     // Check that all fifos are homogeneous and without delay
-    boolean homogeneousRates = actor.getDataOutputPorts().stream().map(DataOutputPort::getFifo)
-        .allMatch(x -> doSwitch(x).booleanValue());
+    boolean homogeneousRates = actor.getDataOutputPorts().stream().allMatch(x -> doSwitch(x.getFifo()).booleanValue());
     // Return false if rates are not homogeneous or that the corresponding actor was a sink (no output)
     if (!homogeneousRates || actor.getDataOutputPorts().isEmpty()) {
       return false;

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/URCSeeker.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/URCSeeker.java
@@ -1,0 +1,90 @@
+package org.preesm.model.pisdf.util;
+
+import java.util.LinkedList;
+import java.util.List;
+import org.preesm.model.pisdf.AbstractActor;
+import org.preesm.model.pisdf.DataOutputPort;
+import org.preesm.model.pisdf.Fifo;
+import org.preesm.model.pisdf.PiGraph;
+
+/**
+ * This class is used to seek chain of actors in a given PiGraph that form a Uniform Repetition Count (URC) without
+ * internal state structure.
+ * 
+ * @author dgageot
+ *
+ */
+public class URCSeeker extends PiMMSwitch<Boolean> {
+
+  /**
+   * Input graph.
+   */
+  final PiGraph graph;
+
+  /**
+   * List of identified URCs.
+   */
+  final List<List<AbstractActor>> identifiedURCs;
+
+  /**
+   * Builds a URCSeeker based on a input graph.
+   * 
+   * @param inputGraph
+   *          Input graph to search in.
+   */
+  public URCSeeker(final PiGraph inputGraph) {
+    this.graph = inputGraph;
+    this.identifiedURCs = new LinkedList<>();
+  }
+
+  /**
+   * Seek for URC chain in the input graph.
+   * 
+   * @return List of identified chain that correspond to a URC.
+   */
+  public List<List<AbstractActor>> seek() {
+    // Clear the list of identified URCs
+    this.identifiedURCs.clear();
+    // Explore all actors of the graph
+    for (AbstractActor actor : this.graph.getActors()) {
+      doSwitch(actor);
+    }
+    return identifiedURCs;
+  }
+
+  @Override
+  public Boolean caseAbstractActor(AbstractActor actor) {
+
+    // Check that all fifos are homogeneous
+    for (DataOutputPort dop : actor.getDataOutputPorts()) {
+      // Rates are homogeneous?
+      if (!doSwitch(dop.getFifo()).booleanValue()) {
+        return false;
+      }
+    }
+
+    // Get the candidate
+    AbstractActor candidate = (AbstractActor) actor.getDataOutputPorts().get(0).getFifo().getTarget();
+
+    // Check that the actually processed actor as only fifo outgoing to the candidate actor
+    boolean allOutputGoesToCandidate = actor.getDataOutputPorts().stream()
+        .allMatch(x -> x.getFifo().getTarget().equals(candidate));
+    // Check that the candidate actor as only fifo incoming from the actually processed actor
+    boolean allInputGoesFromActor = candidate.getDataInputPorts().stream()
+        .allMatch(x -> x.getFifo().getSource().equals(actor));
+
+    // If the candidate agree with the conditions, register this URC
+    if (allOutputGoesToCandidate && allInputGoesFromActor) {
+      // TODO : Register URC in identifiedURCs
+    }
+
+    return true;
+  }
+
+  @Override
+  public Boolean caseFifo(Fifo fifo) {
+    // Returns true if rates are homogeneous
+    return fifo.getSourcePort().getExpression().evaluate() == fifo.getTargetPort().getExpression().evaluate();
+  }
+
+}

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/URCSeeker.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/URCSeeker.java
@@ -55,10 +55,10 @@ public class URCSeeker extends PiMMSwitch<Boolean> {
   @Override
   public Boolean caseAbstractActor(AbstractActor actor) {
 
-    // Check that all fifos are homogeneous
+    // Check that all fifos are homogeneous and without delay
     boolean homogeneousRates = actor.getDataOutputPorts().stream().map(DataOutputPort::getFifo)
         .allMatch(x -> doSwitch(x).booleanValue());
-    // Return false if rates are not homogeneous
+    // Return false if rates are not homogeneous or that the corresponding actor was a sink (no output)
     if (!homogeneousRates || actor.getDataOutputPorts().isEmpty()) {
       return false;
     }
@@ -91,6 +91,7 @@ public class URCSeeker extends PiMMSwitch<Boolean> {
         this.identifiedURCs.add(actorURC);
       }
 
+      // Base URC found for candidate?
       Optional<List<AbstractActor>> candidateListOpt = this.identifiedURCs.stream().filter(x -> x.contains(candidate))
           .findFirst();
       if (candidateListOpt.isPresent()) {
@@ -111,8 +112,9 @@ public class URCSeeker extends PiMMSwitch<Boolean> {
 
   @Override
   public Boolean caseFifo(Fifo fifo) {
-    // Returns true if rates are homogeneous
-    return fifo.getSourcePort().getExpression().evaluate() == fifo.getTargetPort().getExpression().evaluate();
+    // Return true if rates are homogeneous and that no delay is involve
+    return (fifo.getSourcePort().getExpression().evaluate() == fifo.getTargetPort().getExpression().evaluate())
+        && (fifo.getDelay() == null);
   }
 
 }

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/URCSeeker.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/URCSeeker.java
@@ -59,7 +59,7 @@ public class URCSeeker extends PiMMSwitch<Boolean> {
     boolean homogeneousRates = actor.getDataOutputPorts().stream().map(DataOutputPort::getFifo)
         .allMatch(x -> doSwitch(x).booleanValue());
     // Return false if rates are not homogeneous
-    if (!homogeneousRates) {
+    if (!homogeneousRates || actor.getDataOutputPorts().isEmpty()) {
       return false;
     }
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -5,6 +5,7 @@ PREESM Changelog
 *XXXX.XX.XX*
 
 ### New Feature
+* Clustering: Uniform Repetition Count chain of actor can be found with the new URCSeeker class.
 
 ### Changes
 

--- a/tests/org.preesm.tests.model/src/org/preesm/model/pisdf/test/URCSeekerTest.java
+++ b/tests/org.preesm.tests.model/src/org/preesm/model/pisdf/test/URCSeekerTest.java
@@ -1,5 +1,6 @@
 package org.preesm.model.pisdf.test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -65,19 +66,24 @@ public class URCSeekerTest {
   }
 
   @Test
-  public void testExpectToGetChainBCD() {
+  public void testExpectToFoundTwoURCs() {
+    assertEquals(this.seekerResults.size(), 2);
+  }
+
+  @Test
+  public void testExpectToFoundChainBCD() {
     List<AbstractActor> expectedChain = Arrays.asList(this.actorB, this.actorC, this.actorD);
     assertTrue(this.seekerResults.contains(expectedChain));
   }
 
   @Test
-  public void testExpectToGetChainEFG() {
+  public void testExpectToFoundChainEFG() {
     List<AbstractActor> expectedChain = Arrays.asList(this.actorE, this.actorF, this.actorG);
     assertTrue(this.seekerResults.contains(expectedChain));
   }
 
   @Test
-  public void testDoesntExpectToGetChainDE() {
+  public void testDoesntExpectToFoundChainDE() {
     List<AbstractActor> expectedChain = Arrays.asList(this.actorD, this.actorE);
     assertFalse(this.seekerResults.contains(expectedChain));
   }
@@ -136,7 +142,7 @@ public class URCSeekerTest {
     this.actorF.getDataInputPorts().add(inputF);
     this.actorG.getDataInputPorts().add(inputG);
 
-    // Create fifos and form a chain such as A -> B -> (x2) C -> D -> (delay) E -> F
+    // Create fifos and form a chain such as A -> B -> (x2) C -> D -> (delay) E -> F -> G
     Fifo fifoAB = PiMMUserFactory.instance.createFifo(outputA, inputB, "void");
     Fifo fifoBC1 = PiMMUserFactory.instance.createFifo(outputB1, inputC1, "void");
     Fifo fifoBC2 = PiMMUserFactory.instance.createFifo(outputB2, inputC2, "void");
@@ -173,6 +179,7 @@ public class URCSeekerTest {
     fifoDE.setDelay(delayDE);
     this.topGraph.addDelay(delayDE);
 
+    // Check consistency of the graph
     PiGraphConsistenceChecker.check(this.topGraph);
   }
 

--- a/tests/org.preesm.tests.model/src/org/preesm/model/pisdf/test/URCSeekerTest.java
+++ b/tests/org.preesm.tests.model/src/org/preesm/model/pisdf/test/URCSeekerTest.java
@@ -1,0 +1,179 @@
+package org.preesm.model.pisdf.test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.preesm.model.pisdf.AbstractActor;
+import org.preesm.model.pisdf.DataInputPort;
+import org.preesm.model.pisdf.DataOutputPort;
+import org.preesm.model.pisdf.Delay;
+import org.preesm.model.pisdf.Fifo;
+import org.preesm.model.pisdf.PiGraph;
+import org.preesm.model.pisdf.check.PiGraphConsistenceChecker;
+import org.preesm.model.pisdf.factory.PiMMUserFactory;
+import org.preesm.model.pisdf.util.URCSeeker;
+
+/**
+ * @author dgageot
+ *
+ */
+public class URCSeekerTest {
+
+  private PiGraph                   topGraph;
+  private AbstractActor             actorA;
+  private AbstractActor             actorB;
+  private AbstractActor             actorC;
+  private AbstractActor             actorD;
+  private AbstractActor             actorE;
+  private AbstractActor             actorF;
+  private AbstractActor             actorG;
+  private URCSeeker                 seeker;
+  private List<List<AbstractActor>> seekerResults;
+
+  /**
+   * Set-up the test environnement
+   */
+  @Before
+  public void setUp() {
+    // Create a chained actors PiGraph
+    createChainedActorsPiGraph();
+    // Build the URC seeker
+    this.seeker = new URCSeeker(this.topGraph);
+    // Retrieve list of URC chain in the graph
+    seekerResults = this.seeker.seek();
+  }
+
+  /**
+   * Teardown the test environnement
+   */
+  @After
+  public void tearDown() {
+    this.topGraph = null;
+    this.actorA = null;
+    this.actorB = null;
+    this.actorC = null;
+    this.actorD = null;
+    this.actorE = null;
+    this.actorF = null;
+    this.actorG = null;
+    this.seeker = null;
+  }
+
+  @Test
+  public void testExpectToGetChainBCD() {
+    List<AbstractActor> expectedChain = Arrays.asList(this.actorB, this.actorC, this.actorD);
+    assertTrue(this.seekerResults.contains(expectedChain));
+  }
+
+  @Test
+  public void testExpectToGetChainEFG() {
+    List<AbstractActor> expectedChain = Arrays.asList(this.actorE, this.actorF, this.actorG);
+    assertTrue(this.seekerResults.contains(expectedChain));
+  }
+
+  @Test
+  public void testDoesntExpectToGetChainDE() {
+    List<AbstractActor> expectedChain = Arrays.asList(this.actorD, this.actorE);
+    assertFalse(this.seekerResults.contains(expectedChain));
+  }
+
+  private void createChainedActorsPiGraph() {
+    // Create the top graph
+    this.topGraph = PiMMUserFactory.instance.createPiGraph();
+    this.topGraph.setName("topgraph");
+    this.topGraph.setUrl("topgraph");
+
+    // Create actors
+    this.actorA = PiMMUserFactory.instance.createActor("A");
+    this.actorB = PiMMUserFactory.instance.createActor("B");
+    this.actorC = PiMMUserFactory.instance.createActor("C");
+    this.actorD = PiMMUserFactory.instance.createActor("D");
+    this.actorE = PiMMUserFactory.instance.createActor("E");
+    this.actorF = PiMMUserFactory.instance.createActor("F");
+    this.actorG = PiMMUserFactory.instance.createActor("G");
+
+    // Create a list for the actors to easily add them to the top graph
+    List<AbstractActor> actorsList = Arrays.asList(this.actorC, this.actorD, this.actorB, this.actorE, this.actorF,
+        this.actorA, this.actorG);
+
+    // Add actors to the top graph
+    actorsList.stream().forEach(x -> this.topGraph.addActor(x));
+
+    // Create data output and input ports
+    DataOutputPort outputA = PiMMUserFactory.instance.createDataOutputPort("out");
+    DataOutputPort outputB1 = PiMMUserFactory.instance.createDataOutputPort("out1");
+    DataOutputPort outputB2 = PiMMUserFactory.instance.createDataOutputPort("out2");
+    DataOutputPort outputC = PiMMUserFactory.instance.createDataOutputPort("out");
+    DataOutputPort outputD = PiMMUserFactory.instance.createDataOutputPort("out");
+    DataOutputPort outputE = PiMMUserFactory.instance.createDataOutputPort("out");
+    DataOutputPort outputF = PiMMUserFactory.instance.createDataOutputPort("out");
+    DataInputPort inputB = PiMMUserFactory.instance.createDataInputPort("in");
+    DataInputPort inputC1 = PiMMUserFactory.instance.createDataInputPort("in1");
+    DataInputPort inputC2 = PiMMUserFactory.instance.createDataInputPort("in2");
+    DataInputPort inputD = PiMMUserFactory.instance.createDataInputPort("in");
+    DataInputPort inputE = PiMMUserFactory.instance.createDataInputPort("in");
+    DataInputPort inputF = PiMMUserFactory.instance.createDataInputPort("in");
+    DataInputPort inputG = PiMMUserFactory.instance.createDataInputPort("in");
+
+    // Attach them to actors
+    this.actorA.getDataOutputPorts().add(outputA);
+    this.actorB.getDataOutputPorts().add(outputB1);
+    this.actorB.getDataOutputPorts().add(outputB2);
+    this.actorC.getDataOutputPorts().add(outputC);
+    this.actorD.getDataOutputPorts().add(outputD);
+    this.actorE.getDataOutputPorts().add(outputE);
+    this.actorF.getDataOutputPorts().add(outputF);
+    this.actorB.getDataInputPorts().add(inputB);
+    this.actorC.getDataInputPorts().add(inputC1);
+    this.actorC.getDataInputPorts().add(inputC2);
+    this.actorD.getDataInputPorts().add(inputD);
+    this.actorE.getDataInputPorts().add(inputE);
+    this.actorF.getDataInputPorts().add(inputF);
+    this.actorG.getDataInputPorts().add(inputG);
+
+    // Create fifos and form a chain such as A -> B -> (x2) C -> D -> (delay) E -> F
+    Fifo fifoAB = PiMMUserFactory.instance.createFifo(outputA, inputB, "void");
+    Fifo fifoBC1 = PiMMUserFactory.instance.createFifo(outputB1, inputC1, "void");
+    Fifo fifoBC2 = PiMMUserFactory.instance.createFifo(outputB2, inputC2, "void");
+    Fifo fifoCD = PiMMUserFactory.instance.createFifo(outputC, inputD, "void");
+    Fifo fifoDE = PiMMUserFactory.instance.createFifo(outputD, inputE, "void");
+    Fifo fifoEF = PiMMUserFactory.instance.createFifo(outputE, inputF, "void");
+    Fifo fifoFG = PiMMUserFactory.instance.createFifo(outputF, inputG, "void");
+
+    // Create a list for the fifos to easily add them to the top graph
+    List<Fifo> fifosList = Arrays.asList(fifoAB, fifoBC1, fifoBC2, fifoCD, fifoDE, fifoEF, fifoFG);
+
+    // Add fifos to the top graph
+    fifosList.stream().forEach(x -> this.topGraph.addFifo(x));
+
+    // Setup data output and input ports rates
+    outputA.setExpression(16);
+    inputB.setExpression(2);
+    outputB1.setExpression(2);
+    outputB2.setExpression(3);
+    inputC1.setExpression(2);
+    inputC2.setExpression(3);
+    outputC.setExpression(3);
+    inputD.setExpression(3);
+    outputD.setExpression(1);
+    inputE.setExpression(1);
+    outputE.setExpression(7);
+    inputF.setExpression(7);
+    outputF.setExpression(5);
+    inputG.setExpression(5);
+
+    // Set delay to fifo DE
+    Delay delayDE = PiMMUserFactory.instance.createDelay();
+    delayDE.setExpression(1);
+    fifoDE.setDelay(delayDE);
+    this.topGraph.addDelay(delayDE);
+
+    PiGraphConsistenceChecker.check(this.topGraph);
+  }
+
+}


### PR DESCRIPTION
This PR adds a utility that seeks for Uniform Repetition Count (URC) chain of actors in a specified PiGraph. A URC can be defined as a chain of actor in which all actors share the same repetition count without having any kind of internal state (no delay). This feature is needed for the future contribution on clustering. Unit tests are provided.

Here is an example of URC from my InnovR report:
![image](https://user-images.githubusercontent.com/5111951/72994331-34c89b00-3df7-11ea-8100-6b9f53cf5319.png)

