### PR TITLE
Cluster attribute in .pi

### DIFF
--- a/plugins/org.preesm.model.pisdf/resources/xsd/PiSDF.xsd
+++ b/plugins/org.preesm.model.pisdf/resources/xsd/PiSDF.xsd
@@ -55,6 +55,7 @@
       </xs:sequence>
       <xs:attribute type="xs:string" name="edgedefault" />
       <xs:attribute type="xs:string" name="period" use="optional" />
+      <xs:attribute type="xs:string" name="cluster" use="optional" />
    </xs:complexType>
 
    <xs:complexType name="Edge">

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/serialize/PiParser.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/serialize/PiParser.java
@@ -722,6 +722,14 @@ public class PiParser {
       graph.setExpression(0);
     }
 
+    final String clusterAttribute = graphElt.getAttribute(PiIdentifiers.CLUSTER);
+    if (clusterAttribute != null && !clusterAttribute.isEmpty()) {
+      graph.setClusterValue(clusterAttribute.contains("true"));
+    } else {
+      // If there is no attribute for cluster value, it means that current PiGraph is not a cluster
+      graph.setClusterValue(false);
+    }
+
     // Parse the elements of the graph
     final NodeList childList = graphElt.getChildNodes();
     for (int i = 0; i < childList.getLength(); i++) {

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/serialize/PiWriter.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/serialize/PiWriter.java
@@ -553,6 +553,10 @@ public class PiWriter {
     if (!periodExpr.equals("0")) {
       graphElt.setAttribute(PiIdentifiers.ACTOR_PERIOD, periodExpr);
     }
+    // Write cluster value into graph element
+    if (graph.isCluster()) {
+      graphElt.setAttribute(PiIdentifiers.CLUSTER, "true");
+    }
 
     for (final Parameter param : graph.getParameters()) {
       writeParameter(graphElt, param);

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiIdentifiers.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiIdentifiers.java
@@ -87,6 +87,9 @@ public class PiIdentifiers {
   /** The Constant GRAPH_DIRECTED. */
   public static final String GRAPH_DIRECTED = "directed";
 
+  /** The Constant CLUSTER. */
+  public static final String CLUSTER = "cluster";
+
   /** The Constant DATA. */
   // DATA
   public static final String DATA = "data";

--- a/release_notes.md
+++ b/release_notes.md
@@ -16,6 +16,7 @@ PREESM Changelog
 * Possibility to set the init function of a delay in the GUI, not yet used in the codegen.
 * Adding new API methods to Parameter class to ease the manipulation of the Parameter tree.
 * Adding new API methods for direct access of FunctionPrototype parameters.
+* Cluster attribute of PiGraph is now printed in .pi.
 
 ### Bug fix
 * Fix ids and icons of a few GUI elements.


### PR DESCRIPTION
This PR adds "cluster" attribute in .pi in order to distinguish if current PiGraph is a cluster or a regular graph. PiParser, PiWrite, PiIndentifiers and PiSDFXSDValidator has been tainted for this feature.