### PR TITLE
Fix cluster issues

### DIFF
--- a/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
+++ b/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
@@ -779,7 +779,7 @@ class CPrinter extends BlankPrinter {
 			output instanceof NullBuffer || input instanceof NullBuffer){
 			return ''''''
 		} else {
-			return '''memcpy(«output.name»+«outOffset», «input.name»+«inOffset», «if (SIMPLE_BUFFER_SIZES) size * engine.scenario.simulationInfo.getDataTypeSizeOrDefault(type) else size+"*sizeof("+type+")"»);'''
+			return '''memcpy(«doSwitch(output)»+«outOffset», «doSwitch(input)»+«inOffset», «if (SIMPLE_BUFFER_SIZES) size * engine.scenario.simulationInfo.getDataTypeSizeOrDefault(type) else size+"*sizeof("+type+")"»);'''
 		}
 	}
 

--- a/plugins/org.preesm.codegen/src/org/preesm/codegen/model/clustering/CodegenClusterModelGeneratorSwitch.java
+++ b/plugins/org.preesm.codegen/src/org/preesm/codegen/model/clustering/CodegenClusterModelGeneratorSwitch.java
@@ -229,7 +229,7 @@ public class CodegenClusterModelGeneratorSwitch extends ScheduleSwitch<CodeElt> 
   public CodeElt caseParallelHiearchicalSchedule(final ParallelHiearchicalSchedule schedule) {
 
     // Is it a data parallelism node?
-    if (schedule.getChildren().size() == 1) {
+    if (schedule.getChildren().size() == 1 && !schedule.hasAttachedActor()) {
       return doSwitch(schedule.getChildren().get(0));
     }
 
@@ -238,9 +238,13 @@ public class CodegenClusterModelGeneratorSwitch extends ScheduleSwitch<CodeElt> 
 
     // Explore and generate child schedule
     for (final Schedule e : schedule.getChildren()) {
-      final SectionBlock sectionBlock = CodegenModelUserFactory.eINSTANCE.createSectionBlock();
-      sectionBlock.getCodeElts().add(doSwitch(e));
-      outputPair.getValue().getCodeElts().add(sectionBlock);
+      if (schedule.getChildren().size() == 1) {
+        outputPair.getValue().getCodeElts().add(doSwitch(e));
+      } else {
+        final SectionBlock sectionBlock = CodegenModelUserFactory.eINSTANCE.createSectionBlock();
+        sectionBlock.getCodeElts().add(doSwitch(e));
+        outputPair.getValue().getCodeElts().add(sectionBlock);
+      }
     }
 
     return outputPair.getKey();

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/statictools/PiSDFToSingleRate.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/statictools/PiSDFToSingleRate.java
@@ -220,7 +220,7 @@ public class PiSDFToSingleRate extends PiMMSwitch<Boolean> {
    *          SRDAG
    */
   private static final void removeUnusedPorts(final PiGraph graph) {
-    for (AbstractActor aa : graph.getAllActors()) {
+    for (AbstractActor aa : graph.getActors()) {
       final Set<DataInputPort> toRemoveIn = new HashSet<>();
       final Set<DataOutputPort> toRemoveOut = new HashSet<>();
       for (DataPort p : aa.getAllDataPorts()) {

--- a/release_notes.md
+++ b/release_notes.md
@@ -17,12 +17,16 @@ PREESM Changelog
 * Adding new API methods to Parameter class to ease the manipulation of the Parameter tree.
 * Adding new API methods for direct access of FunctionPrototype parameters.
 * Cluster attribute of PiGraph is now printed in .pi.
+* Cluster codegen :
+ * MD5 checking can be printed for sink actors contained in a cluster.
+ * Parallel Hierarchy with one children is not considered anymore as a section block.
 
 ### Bug fix
 * Fix ids and icons of a few GUI elements.
 * Fix expression evaluation exception management.
 * Fix false parsing of deleted component in scenario.
-
+* Fix SRDAG exploration of cluster special actor.
+* Fix the way how delay are printed in cluster codegen.
 
 ## Release version 3.19.0
 *2020.01.10*


### PR DESCRIPTION
This PR fixes some issue such as:
- Delay push/pop in the cluster codegen: popping wasn't correctly printed.
- Cluster exploration in PiSDFToSingleRate: it was exploring children actors of clusters, so special actor port contained in a cluster were tainted, it leads the cluster codegen to throw a NPE.
- Parallel hierarchy processing in cluster codegen: hierarchy that has only one children schedule tree was considered as a data parallel node. That assumption was false, instead, we check if it has an attached actor in order to deduce if it is a data parallel node, otherwise it's attached to a cluster and need to be built a cluster block.