### PR TITLE
PiGraph firing balancer

### DIFF
--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiGraphFiringBalancer.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/util/PiGraphFiringBalancer.java
@@ -1,0 +1,101 @@
+package org.preesm.model.pisdf.util;
+
+import org.preesm.commons.exceptions.PreesmRuntimeException;
+import org.preesm.model.pisdf.DataInputInterface;
+import org.preesm.model.pisdf.DataInputPort;
+import org.preesm.model.pisdf.DataOutputInterface;
+import org.preesm.model.pisdf.DataOutputPort;
+import org.preesm.model.pisdf.PiGraph;
+
+/**
+ * This class is used to balance repetition count of a given PiGraph with a specified factor that is power of two.
+ *
+ * @author dgageot
+ *
+ */
+public class PiGraphFiringBalancer extends PiMMSwitch<Boolean> {
+
+  /**
+   * PiGraph to process.
+   */
+  private final PiGraph graph;
+
+  /**
+   * Balancing factor.
+   */
+  private final int balancingFactor;
+
+  /**
+   * Builds a PiGraphFiringBalancer based on the subgraph to process.
+   * 
+   * @param graph
+   *          Input PiGraph to process. Must be contained in another PiGraph.
+   * @param balancingFactor
+   *          Balancing factor, must be power of 2.
+   */
+  public PiGraphFiringBalancer(final PiGraph graph, final int balancingFactor) {
+    // If the given PiGraph is not contained in a graph, throw an exception.
+    if (graph.getContainingPiGraph() == null) {
+      throw new PreesmRuntimeException("PiGraphFiringBalancer: " + graph.getName() + " has no parent graph.");
+    }
+    this.graph = graph;
+    // If balancing factor is not power of 2, throw an exception.
+    double estimatedPower = Math.log(balancingFactor) / Math.log(2);
+    if (Math.ceil(estimatedPower) != Math.floor(estimatedPower)) {
+      throw new PreesmRuntimeException(
+          "PiGraphFiringBalancer: balancing factor " + balancingFactor + " is not power of 2.");
+    }
+    this.balancingFactor = balancingFactor;
+  }
+
+  /**
+   * Balance the repetition count of the hierarchy with a specified factor. As an example, if factor equals 2,
+   * expressions on graph data ports would be multiplied by 2, leading to divide by 2 the number of firing of the whole
+   * hierarchy, but multiply by two firings of internal actors.
+   */
+  public void balance() {
+    doSwitch(this.graph);
+  }
+
+  @Override
+  public Boolean casePiGraph(PiGraph graph) {
+    // Process all input interfaces.
+    for (DataInputInterface inputInterface : graph.getDataInputInterfaces()) {
+      doSwitch(inputInterface);
+    }
+    // Process all output interfaces.
+    for (DataOutputInterface outputInterface : graph.getDataOutputInterfaces()) {
+      doSwitch(outputInterface);
+    }
+    return super.casePiGraph(graph);
+  }
+
+  @Override
+  public Boolean caseDataInputPort(DataInputPort dataPort) {
+    Long newExpression = dataPort.getExpression().evaluate() * this.balancingFactor;
+    dataPort.setExpression(newExpression);
+    return true;
+  }
+
+  @Override
+  public Boolean caseDataOutputPort(DataOutputPort dataPort) {
+    Long newExpression = dataPort.getExpression().evaluate() * this.balancingFactor;
+    dataPort.setExpression(newExpression);
+    return true;
+  }
+
+  @Override
+  public Boolean caseDataInputInterface(DataInputInterface inputInterface) {
+    doSwitch(inputInterface.getDataPort());
+    doSwitch(inputInterface.getGraphPort());
+    return true;
+  }
+
+  @Override
+  public Boolean caseDataOutputInterface(DataOutputInterface outputInterface) {
+    doSwitch(outputInterface.getDataPort());
+    doSwitch(outputInterface.getGraphPort());
+    return true;
+  }
+
+}

--- a/release_notes.md
+++ b/release_notes.md
@@ -5,7 +5,9 @@ PREESM Changelog
 *XXXX.XX.XX*
 
 ### New Feature
-* Clustering: Uniform Repetition Count chain of actor can be found with the new URCSeeker class.
+* Clustering: 
+ * Uniform Repetition Count chain of actor can be found with the new URCSeeker class.
+ * Repetition count on a given PiSDF hierarchy can be balanced between coarse-grained and fine-grained levels with the new PiGraphFiringBalancer class.
 * Model: new class of parameter : Malleable Parameter, accepting a set of possible values.
 * Workflow: new task "pisdf-mparams.setter" to compute best value of malleable parameters (naive version).
 * Workflow: new task "org.preesm.codegen.xtend.Spider2CodegenTask" to generate code for Spider 2 runtime.

--- a/tests/org.preesm.tests.model/src/org/preesm/model/pisdf/test/PiGraphFiringBalancerTest.java
+++ b/tests/org.preesm.tests.model/src/org/preesm/model/pisdf/test/PiGraphFiringBalancerTest.java
@@ -1,0 +1,184 @@
+package org.preesm.model.pisdf.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.preesm.commons.exceptions.PreesmRuntimeException;
+import org.preesm.model.pisdf.AbstractActor;
+import org.preesm.model.pisdf.AbstractVertex;
+import org.preesm.model.pisdf.DataInputPort;
+import org.preesm.model.pisdf.DataOutputPort;
+import org.preesm.model.pisdf.Fifo;
+import org.preesm.model.pisdf.PiGraph;
+import org.preesm.model.pisdf.brv.BRVMethod;
+import org.preesm.model.pisdf.brv.PiBRV;
+import org.preesm.model.pisdf.check.PiGraphConsistenceChecker;
+import org.preesm.model.pisdf.factory.PiMMUserFactory;
+import org.preesm.model.pisdf.util.PiGraphFiringBalancer;
+import org.preesm.model.pisdf.util.PiSDFSubgraphBuilder;
+
+/**
+ * @author dgageot
+ *
+ */
+public class PiGraphFiringBalancerTest {
+
+  private PiGraph       topGraph;
+  private PiGraph       subGraph;
+  private AbstractActor actorA;
+  private AbstractActor actorB;
+  private AbstractActor actorC;
+  private AbstractActor actorD;
+
+  /**
+   * Set-up the test environnement
+   */
+  @Before
+  public void setUp() {
+    // Create a test environment
+    createTestEnvironment();
+  }
+
+  /**
+   * Teardown the test environnement
+   */
+  @After
+  public void tearDown() {
+    this.topGraph = null;
+    this.subGraph = null;
+    this.actorA = null;
+    this.actorB = null;
+    this.actorC = null;
+    this.actorD = null;
+  }
+
+  @Test
+  public void testFactor2() {
+    new PiGraphFiringBalancer(this.subGraph, 2).balance();
+    Map<AbstractVertex, Long> brv = PiBRV.compute(topGraph, BRVMethod.LCM);
+    assertEquals(Long.valueOf(128), brv.get(this.subGraph));
+    assertEquals(Long.valueOf(2), brv.get(this.actorB));
+    assertEquals(Long.valueOf(2), brv.get(this.actorC));
+  }
+
+  @Test
+  public void testFactor4() {
+    new PiGraphFiringBalancer(this.subGraph, 4).balance();
+    Map<AbstractVertex, Long> brv = PiBRV.compute(topGraph, BRVMethod.LCM);
+    assertEquals(Long.valueOf(64), brv.get(this.subGraph));
+    assertEquals(Long.valueOf(4), brv.get(this.actorB));
+    assertEquals(Long.valueOf(4), brv.get(this.actorC));
+  }
+
+  @Test
+  public void testFactor8() {
+    new PiGraphFiringBalancer(this.subGraph, 8).balance();
+    Map<AbstractVertex, Long> brv = PiBRV.compute(topGraph, BRVMethod.LCM);
+    assertEquals(Long.valueOf(32), brv.get(this.subGraph));
+    assertEquals(Long.valueOf(8), brv.get(this.actorB));
+    assertEquals(Long.valueOf(8), brv.get(this.actorC));
+  }
+
+  @Test
+  public void testFactor16() {
+    new PiGraphFiringBalancer(this.subGraph, 16).balance();
+    Map<AbstractVertex, Long> brv = PiBRV.compute(topGraph, BRVMethod.LCM);
+    assertEquals(Long.valueOf(16), brv.get(this.subGraph));
+    assertEquals(Long.valueOf(16), brv.get(this.actorB));
+    assertEquals(Long.valueOf(16), brv.get(this.actorC));
+  }
+
+  @Test
+  public void testExceptionFactor() {
+    try {
+      new PiGraphFiringBalancer(this.subGraph, 15).balance();
+      assertTrue(false);
+    } catch (PreesmRuntimeException e) {
+      assertTrue(true);
+    }
+  }
+
+  @Test
+  public void testExceptionGraph() {
+    try {
+      new PiGraphFiringBalancer(this.topGraph, 16).balance();
+      assertTrue(false);
+    } catch (PreesmRuntimeException e) {
+      assertTrue(true);
+    }
+    try {
+      new PiGraphFiringBalancer(null, 16).balance();
+      assertTrue(false);
+    } catch (PreesmRuntimeException e) {
+      assertTrue(true);
+    }
+  }
+
+  private void createTestEnvironment() {
+    // Create the top graph
+    this.topGraph = PiMMUserFactory.instance.createPiGraph();
+    this.topGraph.setName("topgraph");
+    this.topGraph.setUrl("topgraph");
+
+    // Create actors
+    this.actorA = PiMMUserFactory.instance.createActor("A");
+    this.actorB = PiMMUserFactory.instance.createActor("B");
+    this.actorC = PiMMUserFactory.instance.createActor("C");
+    this.actorD = PiMMUserFactory.instance.createActor("D");
+
+    // Create a list for the actors to easily add them to the top graph
+    List<AbstractActor> actorsList = Arrays.asList(this.actorA, this.actorB, this.actorC, this.actorD);
+
+    // Add actors to the top graph
+    actorsList.stream().forEach(x -> this.topGraph.addActor(x));
+
+    // Create data output and input ports
+    DataOutputPort outputA = PiMMUserFactory.instance.createDataOutputPort("out");
+    DataOutputPort outputB = PiMMUserFactory.instance.createDataOutputPort("out");
+    DataOutputPort outputC = PiMMUserFactory.instance.createDataOutputPort("out");
+    DataInputPort inputB = PiMMUserFactory.instance.createDataInputPort("in");
+    DataInputPort inputC = PiMMUserFactory.instance.createDataInputPort("in");
+    DataInputPort inputD = PiMMUserFactory.instance.createDataInputPort("in");
+
+    // Attach them to actors
+    this.actorA.getDataOutputPorts().add(outputA);
+    this.actorB.getDataInputPorts().add(inputB);
+    this.actorB.getDataOutputPorts().add(outputB);
+    this.actorC.getDataInputPorts().add(inputC);
+    this.actorC.getDataOutputPorts().add(outputC);
+    this.actorD.getDataInputPorts().add(inputD);
+
+    // Create fifos and form a chain such as A -> B -> C -> D
+    Fifo fifoAB = PiMMUserFactory.instance.createFifo(outputA, inputB, "void");
+    Fifo fifoBC = PiMMUserFactory.instance.createFifo(outputB, inputC, "void");
+    Fifo fifoCD = PiMMUserFactory.instance.createFifo(outputC, inputD, "void");
+
+    // Create a list for the fifos to easily add them to the top graph
+    List<Fifo> fifosList = Arrays.asList(fifoAB, fifoBC, fifoCD);
+
+    // Add fifos to the top graph
+    fifosList.stream().forEach(x -> this.topGraph.addFifo(x));
+
+    // Setup data output and input ports rates
+    outputA.setExpression(256);
+    inputB.setExpression(1);
+    outputB.setExpression(1);
+    inputC.setExpression(1);
+    outputC.setExpression(1);
+    inputD.setExpression(256);
+
+    // Regroup under the same hierarchy actors B and C
+    this.subGraph = new PiSDFSubgraphBuilder(this.topGraph, Arrays.asList(this.actorB, this.actorC), "subgraph_0")
+        .build();
+
+    // Check consistency of the graph
+    PiGraphConsistenceChecker.check(this.topGraph);
+  }
+
+}


### PR DESCRIPTION
This PR introduces a new tool to balance repetition count of a PiSDF hierarchy between coarse-grained and fine-grained parallelism. Unit tests are provided. 

![Figure 1](https://i.imgur.com/pbMtm1Y.png)
__Figure 1: Sobel-Morpho application described with a PiSDF graph__

For example, the Sobel-Morpho application graph has shown by the Figure 1 has a URC chain composed of actors Sobel, Dilation and Erosion. The common repetition count is equal to the number of slices that the input image is stripped by. Let's say that the number of slice is *N*=16. If the chain is clustered, the resulting cluster actor will be repeated 16 times in a graph iteration. Instead of this behavior, interface of the new hierarchy that contained the three actor can be tweaked to balance the repetition count. For example, if we divide by 4 the number of repetition count of the cluster actor, it means that its data output and input port rates has been multipled by 4. It results in a global repetition count of 4 from the top graph, and 4 repetition for every contained actor. By doing so, we balanced fine and coarse-grained parallelism.