### PR TITLE
Fix wrong computation for periodic scheduling necessary condition

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -9,7 +9,7 @@ PREESM Changelog
 ### Changes
 
 ### Bug fix
-
+* Fix wrong computation in workflow task: org.ietr.preesm.pimm.algorithm.checker.periods.PeriodsPreschedulingChecker
 
 ## Release version 3.20.0
 *2020.05.27*


### PR DESCRIPTION
This PR fixes a wrong computation in the workflow task checking a necessary condition for periodic scheduling.