### PR TITLE
(Common) Fix Windows error when parsing an URI from the workspace.

### DIFF
--- a/plugins/org.preesm.commons/src/org/preesm/commons/files/URLResolver.java
+++ b/plugins/org.preesm.commons/src/org/preesm/commons/files/URLResolver.java
@@ -39,6 +39,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -121,6 +122,8 @@ public final class URLResolver {
       try {
         resultURL = resolveFileSystemURL(location);
       } catch (final MalformedURLException e) {
+        resultURL = null;
+      } catch (final InvalidPathException e) {
         resultURL = null;
       }
     }

--- a/plugins/org.preesm.commons/src/org/preesm/commons/files/URLResolver.java
+++ b/plugins/org.preesm.commons/src/org/preesm/commons/files/URLResolver.java
@@ -121,9 +121,7 @@ public final class URLResolver {
     if (resultURL == null) {
       try {
         resultURL = resolveFileSystemURL(location);
-      } catch (final MalformedURLException e) {
-        resultURL = null;
-      } catch (final InvalidPathException e) {
+      } catch (final MalformedURLException | InvalidPathException e) {
         resultURL = null;
       }
     }

--- a/release_notes.md
+++ b/release_notes.md
@@ -10,7 +10,7 @@ PREESM Changelog
 
 ### Bug fix
 * Fix wrong computation in workflow task: org.ietr.preesm.pimm.algorithm.checker.periods.PeriodsPreschedulingChecker
-* Fix parsing error on Windows when parsing a header from the GUI: org.preesm.commons.files.URIResolver.
+* Fix #324 : parsing error on Windows when parsing a header from the GUI (org.preesm.commons.files.URLResolver).
 
 ## Release version 3.20.0
 *2020.05.27*

--- a/release_notes.md
+++ b/release_notes.md
@@ -10,6 +10,7 @@ PREESM Changelog
 
 ### Bug fix
 * Fix wrong computation in workflow task: org.ietr.preesm.pimm.algorithm.checker.periods.PeriodsPreschedulingChecker
+* Fix parsing error on Windows when parsing a header from the GUI: org.preesm.commons.files.URIResolver.
 
 ## Release version 3.20.0
 *2020.05.27*


### PR DESCRIPTION
Fix for issue #324
Added an additional exception catch in the URIResolver.

I'm not sure what the implications may be and if something may be broken by this change.