### PR TITLE
Fix dependency, a test, and github actions workflow.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: 3.6.3
       - name: Build & Test
         shell: bash
         run: releng/build_and_test.sh --ci        

--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,6 @@ new-site
 # Eclipse files #
 #################
 **/.metadata
-
+*.polyglot.category.xml
+*.polyglot.META-INF
+*.polyglot.pom.tycho

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -38,6 +38,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.5</version>
 </extension>
 </extensions>

--- a/plugins/org.preesm.ui.slam/META-INF/MANIFEST.MF
+++ b/plugins/org.preesm.ui.slam/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: PREESM :: Plugins :: Salm UI
+Bundle-Name: PREESM :: Plugins :: Slam UI
 Automatic-Module-Name: org.preesm.ui.slam.singleton.true
 Bundle-SymbolicName: org.preesm.ui.slam;singleton:=true
 Bundle-Version: 3.21.0.qualifier

--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,10 @@
       <rcptt-version>2.4.3</rcptt-version>
       <rcptt-runner-version>2.4.3</rcptt-runner-version>
       <preesm.coding.policy.version>1.3.1</preesm.coding.policy.version>
-      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.release>17</maven.compiler.release>
+      <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
       <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
+
 
       <!-- ############## -->
       <!-- XCORE CONFIG -->
@@ -93,7 +95,7 @@
       <emf-version>2.27.0</emf-version>
       <emf-common-version>2.25.0</emf-common-version>
       <emf-codegen-version>2.30.0</emf-codegen-version>
-      <xtext-version>2.27.0</xtext-version>
+      <xtext-version>2.29.0</xtext-version>
       <ecore-xtext-version>1.6.0</ecore-xtext-version>
       <ecore-xcore-version>1.21.0</ecore-xcore-version>
       <ecore-xcore-lib-version>1.6.0</ecore-xcore-lib-version>
@@ -216,7 +218,7 @@
                      <root>${basedir}/model</root>
                   </sourceRoots>
                   <failOnValidationError>false</failOnValidationError>
-                  <javasourceversion>1.8</javasourceversion>
+                  <javasourceversion>${maven.compiler.release}</javasourceversion>
                </configuration>
                <dependencies>
                   <dependency>
@@ -240,8 +242,8 @@
             <artifactId>maven-compiler-plugin</artifactId>
             <version>3.8.0</version>
             <configuration>
-               <source>1.8</source>
-               <target>1.8</target>
+               <source>${maven.compiler.release}</source>
+               <target>${maven.compiler.release}</target>
             </configuration>
          </plugin>
          <!-- Directory plugin to find parent root directory absolute path -->
@@ -485,7 +487,7 @@
                      <version>3.3.9</version>
                   </requireMavenVersion>
                   <requireJavaVersion>
-                     <version>1.8</version>
+                     <version>${maven.compiler.release}</version>
                   </requireJavaVersion>
                   <!--<dependencyConvergence/> -->
                </rules>
@@ -493,24 +495,30 @@
          </plugin>
 
          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-source-feature-plugin</artifactId>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>tycho-source-plugin</artifactId>
             <version>${tycho-version}</version>
             <executions>
                <execution>
-                  <id>source-feature</id>
+                  <id>feature-source</id>
                   <phase>package</phase>
                   <goals>
-                     <goal>source-feature</goal>
+                     <goal>feature-source</goal>
                   </goals>
                   <configuration>
                      <labelSuffix>&nbsp;Sources
                      </labelSuffix>
                   </configuration>
                </execution>
+               <execution>
+                  <id>plugin-source</id>
+                  <goals>
+                     <goal>plugin-source</goal>
+                  </goals>
+               </execution>
             </executions>
          </plugin>
-
+ <!--
          <plugin>
             <groupId>org.eclipse.tycho</groupId>
             <artifactId>tycho-source-plugin</artifactId>
@@ -524,7 +532,7 @@
                </execution>
             </executions>
          </plugin>
-
+-->
          <plugin>
             <groupId>org.eclipse.tycho</groupId>
             <artifactId>tycho-p2-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 
    <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <jacoco-version>0.8.4</jacoco-version>
+      <jacoco-version>0.8.8</jacoco-version>
       <tycho-version>2.7.5</tycho-version>
       <findbugs-version>3.0.5</findbugs-version>
       <sonar-version>3.9.1.2184</sonar-version>

--- a/pom.xml
+++ b/pom.xml
@@ -518,21 +518,7 @@
                </execution>
             </executions>
          </plugin>
- <!--
-         <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-source-plugin</artifactId>
-            <version>${tycho-version}</version>
-            <executions>
-               <execution>
-                  <id>plugin-source</id>
-                  <goals>
-                     <goal>plugin-source</goal>
-                  </goals>
-               </execution>
-            </executions>
-         </plugin>
--->
+
          <plugin>
             <groupId>org.eclipse.tycho</groupId>
             <artifactId>tycho-p2-plugin</artifactId>
@@ -550,15 +536,6 @@
          <plugin>
            <groupId>org.eclipse.tycho</groupId>
            <artifactId>tycho-surefire-plugin</artifactId>
-		    <executions>
-		      <execution>
-		        <id>test</id>
-		        <phase>test</phase>
-		        <goals>
-		          <goal>test</goal>
-		        </goals>
-		      </execution>
-		    </executions>
             <configuration>
                 <includes>
             		<include>**/*Test.java</include>

--- a/releng/build_and_test.sh
+++ b/releng/build_and_test.sh
@@ -69,6 +69,8 @@ echo "Build goal = ${BUILDGOAL}"
 echo " --"
 echo ""
 
+mvn --version
+
 #flush maven local repo
 mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout
 

--- a/releng/build_and_test.sh
+++ b/releng/build_and_test.sh
@@ -71,7 +71,9 @@ echo ""
 
 
 (cd $DIR && ./releng/fetch-rcptt-runner.sh)
-time (cd $DIR && mvn -e -c -X ${BATCHMODE} clean ${BUILDGOAL} ${TESTMODE})
+time (cd $DIR && mvn -X -e -c ${BATCHMODE} clean ${BUILDGOAL} ${TESTMODE} &> maven.log)
+
+cat maven.log
 
 # Sonar
 if [ "${SONAR}" == "YES" ]; then

--- a/releng/build_and_test.sh
+++ b/releng/build_and_test.sh
@@ -69,23 +69,17 @@ echo "Build goal = ${BUILDGOAL}"
 echo " --"
 echo ""
 
-#flush maven local repo
-#mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout
-
-#setup maven wrapper
-mvn -q -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
-
 (cd $DIR && ./releng/fetch-rcptt-runner.sh)
 
 echo "rcptt-runner DONE"
 
-time (cd $DIR && ./mvnw -e -c ${BATCHMODE} clean ${BUILDGOAL} ${TESTMODE})
+time (cd $DIR && mvn -e -c ${BATCHMODE} clean ${BUILDGOAL} ${TESTMODE})
 
 # Sonar
 if [ "${SONAR}" == "YES" ]; then
   # needs to be run in a second step; See:
   # https://community.sonarsource.com/t/jacoco-coverage-switch-from-deprecated-binary-to-xml-format-in-a-tycho-build-shows-0/
-  (cd $DIR && ./mvnw -e -c ${BATCHMODE} -Dtycho.mode=maven jacoco:report -Djacoco.dataFile=../../target/jacoco.exec -Dsonar.projectKey=preesm_preesm -Dsonar.login=$SONAR_TOKEN sonar:sonar )
+  (cd $DIR && mvn -e -c ${BATCHMODE} -Dtycho.mode=maven jacoco:report -Djacoco.dataFile=../../target/jacoco.exec -Dsonar.projectKey=preesm_preesm -Dsonar.login=$SONAR_TOKEN sonar:sonar )
 
 
 fi

--- a/releng/build_and_test.sh
+++ b/releng/build_and_test.sh
@@ -69,13 +69,11 @@ echo "Build goal = ${BUILDGOAL}"
 echo " --"
 echo ""
 
-mvn --version
-
 #flush maven local repo
-mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout
+#mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout
 
 (cd $DIR && ./releng/fetch-rcptt-runner.sh)
-time (cd $DIR && mvn -X -e -c ${BATCHMODE} clean ${BUILDGOAL} ${TESTMODE})
+time (cd $DIR && mvn -q -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3 && ./mvnw -e -c ${BATCHMODE} clean ${BUILDGOAL} ${TESTMODE})
 
 # Sonar
 if [ "${SONAR}" == "YES" ]; then

--- a/releng/build_and_test.sh
+++ b/releng/build_and_test.sh
@@ -71,7 +71,7 @@ echo ""
 
 
 (cd $DIR && ./releng/fetch-rcptt-runner.sh)
-time (cd $DIR && mvn -e -c ${BATCHMODE} clean ${BUILDGOAL} ${TESTMODE})
+time (cd $DIR && mvn -e -c -X ${BATCHMODE} clean ${BUILDGOAL} ${TESTMODE})
 
 # Sonar
 if [ "${SONAR}" == "YES" ]; then

--- a/releng/build_and_test.sh
+++ b/releng/build_and_test.sh
@@ -70,9 +70,6 @@ echo " --"
 echo ""
 
 (cd $DIR && ./releng/fetch-rcptt-runner.sh)
-
-echo "rcptt-runner DONE"
-
 time (cd $DIR && mvn -e -c ${BATCHMODE} clean ${BUILDGOAL} ${TESTMODE})
 
 # Sonar

--- a/releng/build_and_test.sh
+++ b/releng/build_and_test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -eu
 
+set -x
+
 function find_free_display_number {
   USEDXDISPLAYS=`find /tmp -maxdepth 1 -type f -name ".X*-lock" | rev | cut -d"/" -f 1 | colrm 1 5 | rev | colrm 1 2`
   for i in {99..1}

--- a/releng/build_and_test.sh
+++ b/releng/build_and_test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -eu
 
-set -x
-
 function find_free_display_number {
   USEDXDISPLAYS=`find /tmp -maxdepth 1 -type f -name ".X*-lock" | rev | cut -d"/" -f 1 | colrm 1 5 | rev | colrm 1 2`
   for i in {99..1}
@@ -71,11 +69,11 @@ echo "Build goal = ${BUILDGOAL}"
 echo " --"
 echo ""
 
+#flush maven local repo
+mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout
 
 (cd $DIR && ./releng/fetch-rcptt-runner.sh)
-time (cd $DIR && mvn -X -e -c ${BATCHMODE} clean ${BUILDGOAL} ${TESTMODE} &> maven.log)
-
-cat maven.log
+time (cd $DIR && mvn -X -e -c ${BATCHMODE} clean ${BUILDGOAL} ${TESTMODE})
 
 # Sonar
 if [ "${SONAR}" == "YES" ]; then

--- a/releng/build_and_test.sh
+++ b/releng/build_and_test.sh
@@ -72,14 +72,20 @@ echo ""
 #flush maven local repo
 #mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout
 
+#setup maven wrapper
+mvn -q -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
+
 (cd $DIR && ./releng/fetch-rcptt-runner.sh)
-time (cd $DIR && mvn -q -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3 && ./mvnw -e -c ${BATCHMODE} clean ${BUILDGOAL} ${TESTMODE})
+
+echo "rcptt-runner DONE"
+
+time (cd $DIR && ./mvnw -e -c ${BATCHMODE} clean ${BUILDGOAL} ${TESTMODE})
 
 # Sonar
 if [ "${SONAR}" == "YES" ]; then
   # needs to be run in a second step; See:
   # https://community.sonarsource.com/t/jacoco-coverage-switch-from-deprecated-binary-to-xml-format-in-a-tycho-build-shows-0/
-  (cd $DIR && mvn -e -c ${BATCHMODE} -Dtycho.mode=maven jacoco:report -Djacoco.dataFile=../../target/jacoco.exec -Dsonar.projectKey=preesm_preesm -Dsonar.login=$SONAR_TOKEN sonar:sonar )
+  (cd $DIR && ./mvnw -e -c ${BATCHMODE} -Dtycho.mode=maven jacoco:report -Djacoco.dataFile=../../target/jacoco.exec -Dsonar.projectKey=preesm_preesm -Dsonar.login=$SONAR_TOKEN sonar:sonar )
 
 
 fi

--- a/releng/fetch-rcptt-runner.sh
+++ b/releng/fetch-rcptt-runner.sh
@@ -19,7 +19,7 @@ if [ ! -e "${HOME}/.m2/repository/org/eclipse/rcptt/runner/rcptt.runner/${RCPTTV
 
   URLVER=$(echo ${RCPTTVER} | sed -e 's#-#/#g')
   wget ${MIRROR}/rcptt/release/${URLVER}/runner/rcptt.runner-${RCPTTVER}.zip -O rcptt.runner-${RCPTTVER}.zip
-  ./mvnw -Dtycho.mode=maven install:install-file -Dfile=rcptt.runner-${RCPTTVER}.zip -DgroupId=org.eclipse.rcptt.runner -DartifactId=rcptt.runner -Dversion=${RCPTTVER} -Dpackaging=zip
+  mvn -Dtycho.mode=maven install:install-file -Dfile=rcptt.runner-${RCPTTVER}.zip -DgroupId=org.eclipse.rcptt.runner -DartifactId=rcptt.runner -Dversion=${RCPTTVER} -Dpackaging=zip
   rm rcptt.runner-${RCPTTVER}.zip
 fi
 

--- a/releng/fetch-rcptt-runner.sh
+++ b/releng/fetch-rcptt-runner.sh
@@ -19,7 +19,7 @@ if [ ! -e "${HOME}/.m2/repository/org/eclipse/rcptt/runner/rcptt.runner/${RCPTTV
 
   URLVER=$(echo ${RCPTTVER} | sed -e 's#-#/#g')
   wget ${MIRROR}/rcptt/release/${URLVER}/runner/rcptt.runner-${RCPTTVER}.zip -O rcptt.runner-${RCPTTVER}.zip
-  mvn -Dtycho.mode=maven install:install-file -Dfile=rcptt.runner-${RCPTTVER}.zip -DgroupId=org.eclipse.rcptt.runner -DartifactId=rcptt.runner -Dversion=${RCPTTVER} -Dpackaging=zip
+  ./mvnw -Dtycho.mode=maven install:install-file -Dfile=rcptt.runner-${RCPTTVER}.zip -DgroupId=org.eclipse.rcptt.runner -DartifactId=rcptt.runner -Dversion=${RCPTTVER} -Dpackaging=zip
   rm rcptt.runner-${RCPTTVER}.zip
 fi
 

--- a/releng/org.preesm.product/.classpath
+++ b/releng/org.preesm.product/.classpath
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/tests/org.preesm.algorithm.tests/META-INF/MANIFEST.MF
+++ b/tests/org.preesm.algorithm.tests/META-INF/MANIFEST.MF
@@ -5,13 +5,17 @@ Automatic-Module-Name: org.preesm.algorithm.tests
 Bundle-SymbolicName: org.preesm.algorithm.tests
 Bundle-Version: 3.21.0.qualifier
 Bundle-Vendor: IETR / INSA Rennes - VAADER
-Fragment-Host: org.preesm.algorithm
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.apache.commons.lang3;bundle-version="3.7.0",
- org.eclipse.core.runtime;bundle-version="3.14.0",
- wrapped.org.apache-extras.beanshell.bsh,
- org.preesm.codegen.xtend
+ org.jgrapht.core;bundle-version="1.1.0",
+ org.preesm.algorithm,
+ org.preesm.cli,
+ org.preesm.codegen,
+ org.preesm.codegen.xtend,
+ org.preesm.model.pisdf,
+ org.preesm.ui,
+ wrapped.org.apache-extras.beanshell.bsh
 Export-Package: org.ietr.dftools.algorithm.test,
  org.ietr.preesm.core.test,
  org.ietr.preesm.deadlock.test,

--- a/tests/org.preesm.algorithm.tests/src/org/ietr/preesm/memory/script/BeanShellInterpreterTest.java
+++ b/tests/org.preesm.algorithm.tests/src/org/ietr/preesm/memory/script/BeanShellInterpreterTest.java
@@ -305,7 +305,7 @@ public class BeanShellInterpreterTest {
   @Test
   public void testFork() throws URISyntaxException, IOException, EvalError {
     final String plugin_name = MEMORY_SCRIPT_PLUGIN;
-    final String script_path = "/scripts/fork.bsh";
+    final String script_path = "/resources/scripts/fork.bsh";
 
     final StringBuffer content = new StringBuffer();
     final File scriptFile = new File("../../plugins/" + plugin_name + "/" + script_path);
@@ -374,7 +374,7 @@ public class BeanShellInterpreterTest {
   @Test
   public void testJoin() throws URISyntaxException, IOException, EvalError {
     final String plugin_name = MEMORY_SCRIPT_PLUGIN;
-    final String script_path = "/scripts/join.bsh";
+    final String script_path = "/resources/scripts/join.bsh";
 
     final StringBuffer content = new StringBuffer();
     final File scriptFile = new File("../../plugins/" + plugin_name + "/" + script_path);
@@ -429,7 +429,7 @@ public class BeanShellInterpreterTest {
   @Test
   public void testRoundBuffer() throws URISyntaxException, IOException, EvalError {
     final String plugin_name = MEMORY_SCRIPT_PLUGIN;
-    final String script_path = "/scripts/roundbuffer.bsh";
+    final String script_path = "/resources/scripts/roundbuffer.bsh";
 
     final StringBuffer content = new StringBuffer();
     final File scriptFile = new File("../../plugins/" + plugin_name + "/" + script_path);
@@ -490,7 +490,7 @@ public class BeanShellInterpreterTest {
   @Test
   public void testBroadCast() throws URISyntaxException, IOException, EvalError {
     final String plugin_name = MEMORY_SCRIPT_PLUGIN;
-    final String script_path = "/scripts/broadcast.bsh";
+    final String script_path = "/resources/scripts/broadcast.bsh";
 
     final StringBuffer content = new StringBuffer();
     final File scriptFile = new File("../../plugins/" + plugin_name + "/" + script_path);


### PR DESCRIPTION
This PR fixes some dependency issues preventing the launch of Preesm within Eclipse.
Forced the version on Maven used on github actions to 3.6.3.
Fixed unit tests running twice.
Bump some dependencies to uniformly use Java 17 and remove about a million warning during unit tests.
Updated .gitignore to omit some generated files.
Fixed org.preesm.product looking for an inexistent bin folder.
Updated BeanShellInterpreterTest which would fail locally but pass remotely.