### PR TITLE
Fix just j version

### DIFF
--- a/plugins/org.preesm.algorithm/src/org/preesm/algorithm/mapper/ui/GanttPlotter.java
+++ b/plugins/org.preesm.algorithm/src/org/preesm/algorithm/mapper/ui/GanttPlotter.java
@@ -58,7 +58,6 @@ import javax.swing.JFrame;
 import javax.swing.JMenuItem;
 import javax.swing.JRootPane;
 import javax.swing.WindowConstants;
-import org.apache.commons.lang3.SystemUtils;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.awt.SWT_AWT;
 import org.eclipse.swt.layout.FillLayout;
@@ -255,7 +254,12 @@ public class GanttPlotter {
 
       final Composite composite = new Composite(form.getBody(), SWT.EMBEDDED | SWT.FILL);
       Frame frame = null;
-      if (!SystemUtils.IS_OS_LINUX) {
+
+      // This fix is now required as we now ship PREESM with the JustJ JDK.
+      // Leaving the original code just in case this issue is resolved some day.
+
+      // if (!SystemUtils.IS_OS_LINUX) {
+      if (false) {
         // related to PREESM issue #303
         // may not work because of a libswt-awt-gtk4928+.so bug which is not our responsability
         // see following bug report

--- a/releng/org.preesm.target-platform/org.preesm.target-platform.target
+++ b/releng/org.preesm.target-platform/org.preesm.target-platform.target
@@ -260,7 +260,7 @@
 			</repositories>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/justj/jres/17/updates/release/latest"/>
+			<repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.7"/>
 			<unit id="org.eclipse.justj.openjdk.hotspot.jre.full.stripped.feature.group" version="17.0.7.v20230425-1502"/>
 		</location>
 	</locations>

--- a/releng/org.preesm.target-platform/org.preesm.target-platform.target
+++ b/releng/org.preesm.target-platform/org.preesm.target-platform.target
@@ -260,8 +260,8 @@
 			</repositories>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.7"/>
-			<unit id="org.eclipse.justj.openjdk.hotspot.jre.full.stripped.feature.group" version="17.0.7.v20230425-1502"/>
+			<repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.8"/>
+			<unit id="org.eclipse.justj.openjdk.hotspot.jre.full.stripped.feature.group" version="17.0.8.v20230801-1951"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
This PR fixes the JustJ version to 17.0.8 and forces Gantt diagrams in dedicated windows