### PR TITLE
Fix codegen issue

### DIFF
--- a/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
+++ b/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
@@ -832,6 +832,12 @@ class CPrinter extends BlankPrinter {
 	    context.put("USER_INCLUDES", findAllCHeaderFileNamesUsed.map["#include \""+ it +"\""].join("\n"));
 
 		var String constants = "#define NB_DESIGN_ELTS "+getEngine.archi.componentInstances.size+"\n#define NB_CORES "+getEngine.codeBlocks.size;
+
+		// Table pairing CoreId in architecture to semaphore id
+		constants = constants.concat("\nenum CORE_ID {\n\t");
+		constants = constants.concat(getEngine.codeBlocks.map[it as CoreBlock].map["PE_" + it.coreID + " /*" + it.name + "*/"].join(", "));
+		constants = constants.concat("\n};");
+
 		if(this.usingPapify == 1){
 			constants = constants.concat("\n\n#ifdef _PREESM_PAPIFY_MONITOR\n#include \"eventLib.h\"\n#endif");
 		}
@@ -1070,7 +1076,7 @@ class CPrinter extends BlankPrinter {
 	«IF (communication.comment.contains("\n"))» */
 	«ENDIF»«ENDIF»«IF communication.isRedundant»//«ENDIF»«communication.direction.toString.toLowerCase»«communication.delimiter.toString.toLowerCase.toFirstUpper»(«IF (communication.
 		direction == Direction::SEND && communication.delimiter == Delimiter::START) ||
-		(communication.direction == Direction::RECEIVE && communication.delimiter == Delimiter::END)»«communication.sendStart.coreContainer.coreID», «communication.receiveStart.coreContainer.coreID»«ENDIF
+		(communication.direction == Direction::RECEIVE && communication.delimiter == Delimiter::END)»PE_«communication.sendStart.coreContainer.coreID», PE_«communication.receiveStart.coreContainer.coreID»«ENDIF
 		»); // «communication.sendStart.coreContainer.name» > «communication.receiveStart.coreContainer.name»
 	'''
 

--- a/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
+++ b/plugins/org.preesm.codegen.xtend/xtend-src/org/preesm/codegen/xtend/printer/c/CPrinter.xtend
@@ -904,6 +904,7 @@ class CPrinter extends BlankPrinter {
 
 		#define _PREESM_NBTHREADS_ «engine.codeBlocks.size»
 		#define _PREESM_MAIN_THREAD_ «mainOperatorId»
+		const int CORE_ID[_PREESM_NBTHREADS_] = {«FOR coreBlock : engine.codeBlocks»«(coreBlock as CoreBlock).coreID»«if(engine.codeBlocks.lastOrNull == coreBlock) {""} else {", "}»«ENDFOR»};
 
 		// application dependent includes
 		#include "preesm_gen.h"
@@ -1037,7 +1038,7 @@ class CPrinter extends BlankPrinter {
 			// Creating threads
 			for (int i = 0; i < _PREESM_NBTHREADS_; i++) {
 				if (i != _PREESM_MAIN_THREAD_) {
-					if(launch(i,&coreThreads[i],coreThreadComputations[i])) {
+					if(launch(CORE_ID[i],&coreThreads[i],coreThreadComputations[i])) {
 						printf("Error: could not launch thread %d\n",i);
 						return 1;
 					}

--- a/plugins/org.preesm.codegen/src/org/preesm/codegen/model/generator/CodegenModelGenerator.java
+++ b/plugins/org.preesm.codegen/src/org/preesm/codegen/model/generator/CodegenModelGenerator.java
@@ -415,7 +415,7 @@ public class CodegenModelGenerator extends AbstractCodegenModelGenerator {
     // 2 - Set CoreBlock ID
     // 3 - Put the buffer declaration in their right place
 
-    // -1 - Add all hosted MemoryObject back in te MemEx
+    // -1 - Add all hosted MemoryObject back in the MemEx
     restoreHostedVertices();
 
     // 0 - Create the Buffers of the MemEx
@@ -632,21 +632,17 @@ public class CodegenModelGenerator extends AbstractCodegenModelGenerator {
           new SrDAGOutsideFetcher(), outsideFetcherOption).generate(this.scheduleMapping.get(originalActor));
 
     } else {
-      ActorPrototypes prototypes = null;
       // If the actor has an IDL refinement
-      if ((refinement instanceof final CodeRefinement cRef) && (cRef.getLanguage() == Language.IDL)) {
+      final ActorPrototypes prototypes = switch (refinement) {
         // Retrieve the prototypes associated to the actor
-        prototypes = getActorPrototypes(dagVertex);
-      } else if (refinement instanceof final ActorPrototypes actorProto) {
+        case final CodeRefinement cRef when cRef.getLanguage() == Language.IDL -> getActorPrototypes(dagVertex);
         // Or if we already extracted prototypes from a .h refinement
-        prototypes = actorProto;
-      }
+        case final ActorPrototypes actorProto -> actorProto;
+        default ->
+          throw new PreesmRuntimeException("Actor (" + dagVertex + ") has no valid refinement (.idl, .h or .graphml)."
+              + " Associate a refinement to this actor before generating code.");
+      };
 
-      if (prototypes == null) {
-        // If the actor has no refinement
-        throw new PreesmRuntimeException("Actor (" + dagVertex + ") has no valid refinement (.idl, .h or .graphml)."
-            + " Associate a refinement to this actor before generating code.");
-      }
       // Generate the loop functionCall
       final Prototype loopPrototype = prototypes.getLoopPrototype();
       if (loopPrototype == null) {
@@ -879,9 +875,6 @@ public class CodegenModelGenerator extends AbstractCodegenModelGenerator {
       mainBuffer.setType("char");
       mainBuffer.setTokenTypeSizeInBit(8); // char is 8 bits
 
-      // To be removed
-      // mainBuffer.setSizeInBit(size);
-      // mainBuffer.setNbToken((long) (size + 7L) / mainBuffer.getTypeSize());
       mainBuffer.setNbToken((long) Math.ceil((double) size / (double) mainBuffer.getTokenTypeSizeInBit()));
       this.mainBuffers.put(memoryBank, mainBuffer);
 

--- a/plugins/org.preesm.codegen/src/org/preesm/codegen/xtend/task/CodegenEngine.java
+++ b/plugins/org.preesm.codegen/src/org/preesm/codegen/xtend/task/CodegenEngine.java
@@ -218,9 +218,6 @@ public class CodegenEngine {
           "Could not find a printer for language \"" + selectedPrinter + "\" and core type \"" + coreType + "\".");
     }
 
-    // if (!this.registeredPrintersAndBlocks.containsKey(foundPrinter)) {
-    // this.registeredPrintersAndBlocks.put(foundPrinter, new ArrayList<>());
-    // }
     this.registeredPrintersAndBlocks.computeIfAbsent(foundPrinter, fp -> new ArrayList<>());
 
     final List<Block> blocks = this.registeredPrintersAndBlocks.get(foundPrinter);

--- a/plugins/org.preesm.commons/src/org/preesm/commons/math/JEPWrapper.java
+++ b/plugins/org.preesm.commons/src/org/preesm/commons/math/JEPWrapper.java
@@ -145,18 +145,15 @@ public class JEPWrapper {
   private static double parse(final String allExpression, final JEP jep) throws ParseException {
     final Node parse = jep.parse(allExpression);
     final Object result = jep.evaluate(parse);
-    if (result instanceof Long) {
-      return (double) result;
-    }
-    if (result instanceof final Double dResult) {
-      if (Double.isInfinite(dResult)) {
+
+    return switch (result) {
+      case final Long lResult -> lResult;
+      case final Double dResult when Double.isInfinite(dResult) ->
         throw new ExpressionEvaluationException("Expression '" + allExpression + "' evaluated to infinity.");
-      }
-      return dResult;
-    }
-    if (result instanceof final Number number) {
-      return number.doubleValue();
-    }
-    throw new ExpressionEvaluationException("Unsupported result type " + result.getClass().getSimpleName());
+      case final Double dResult -> dResult;
+      case final Number number -> number.doubleValue();
+      default ->
+        throw new ExpressionEvaluationException("Unsupported result type " + result.getClass().getSimpleName());
+    };
   }
 }

--- a/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/serialize/PiWriter.java
+++ b/plugins/org.preesm.model.pisdf/src/org/preesm/model/pisdf/serialize/PiWriter.java
@@ -85,6 +85,7 @@ import org.preesm.model.pisdf.PiSDFRefinement;
 import org.preesm.model.pisdf.Port;
 import org.preesm.model.pisdf.Refinement;
 import org.preesm.model.pisdf.RoundBufferActor;
+import org.preesm.model.pisdf.SpecialActor;
 import org.preesm.model.pisdf.check.CheckerErrorLevel;
 import org.preesm.model.pisdf.check.PiGraphConsistenceChecker;
 import org.preesm.model.pisdf.reconnection.SubgraphOriginalActorTracker;
@@ -230,14 +231,13 @@ public class PiWriter {
 
     // Add the name in the data of the node
 
-    if (abstractActor instanceof final PiGraph piGraph) {
-      writePiGraphAsHActor(vertexElt, piGraph);
-    } else if (abstractActor instanceof final Actor actor) {
-      writeActor(vertexElt, actor);
-    } else if (abstractActor instanceof ExecutableActor) {
-      writeSpecialActor(vertexElt, abstractActor);
-    } else if (abstractActor instanceof final InterfaceActor iActor) {
-      writeInterfaceVertex(vertexElt, iActor);
+    switch (abstractActor) {
+      case final PiGraph piGraph -> writePiGraphAsHActor(vertexElt, piGraph);
+      case final Actor actor -> writeActor(vertexElt, actor);
+      case final SpecialActor specialActor -> writeSpecialActor(vertexElt, specialActor);
+      case final InterfaceActor iActor -> writeInterfaceVertex(vertexElt, iActor);
+      default -> {
+        /* Nothing */ }
     }
   }
 
@@ -708,27 +708,28 @@ public class PiWriter {
    * @param actor
    *          The {@link Actor} to serialize
    */
-  protected void writeSpecialActor(final Element vertexElt, final AbstractActor actor) {
-    String kind = null;
-    if (actor instanceof BroadcastActor) {
-      kind = PiIdentifiers.BROADCAST;
-    } else if (actor instanceof JoinActor) {
-      kind = PiIdentifiers.JOIN;
-    } else if (actor instanceof ForkActor) {
-      kind = PiIdentifiers.FORK;
-    } else if (actor instanceof RoundBufferActor) {
-      kind = PiIdentifiers.ROUND_BUFFER;
-    } else if (actor instanceof final EndActor endActor) {
-      kind = PiIdentifiers.END;
-      if (endActor.getInitReference() != null) {
-        vertexElt.setAttribute(PiIdentifiers.INIT_END_REF, endActor.getInitReference().getName());
+  protected void writeSpecialActor(final Element vertexElt, final SpecialActor actor) {
+
+    final String kind = switch (actor) {
+      case final BroadcastActor brd -> PiIdentifiers.BROADCAST;
+      case final JoinActor join -> PiIdentifiers.JOIN;
+      case final ForkActor fork -> PiIdentifiers.FORK;
+      case final RoundBufferActor rb -> PiIdentifiers.ROUND_BUFFER;
+      case final EndActor endActor -> {
+        if (endActor.getInitReference() != null) {
+          vertexElt.setAttribute(PiIdentifiers.INIT_END_REF, endActor.getInitReference().getName());
+        }
+        yield PiIdentifiers.END;
       }
-    } else if (actor instanceof final InitActor initActor) {
-      kind = PiIdentifiers.INIT;
-      if (initActor.getEndReference() != null) {
-        vertexElt.setAttribute(PiIdentifiers.INIT_END_REF, initActor.getEndReference().getName());
+      case final InitActor initActor -> {
+        if (initActor.getEndReference() != null) {
+          vertexElt.setAttribute(PiIdentifiers.INIT_END_REF, initActor.getEndReference().getName());
+        }
+        yield PiIdentifiers.INIT;
       }
-    }
+      default -> throw new IllegalArgumentException("Unexpected value: " + actor);
+    };
+
     vertexElt.setAttribute(PiIdentifiers.NODE_KIND, kind);
 
     writePorts(vertexElt, actor.getConfigInputPorts());


### PR DESCRIPTION
Fixed #335. The codegen now creates an enumeration from hardwareIds in preesm_gen.h to use with semaphores, preventing out of bound accesses. Communication functions use this enumeration.
Thread affinity now relies on hardwareId in slam, fixing secondary issue mentioned in #335.